### PR TITLE
Rename '<root>' node to '[external]'.

### DIFF
--- a/programl/graph/program_graph_builder.cc
+++ b/programl/graph/program_graph_builder.cc
@@ -26,7 +26,7 @@ namespace graph {
 
 ProgramGraphBuilder::ProgramGraphBuilder() {
   // Create the graph root node.
-  AddNode(Node::INSTRUCTION, "<root>");
+  AddNode(Node::INSTRUCTION, "[external]");
 }
 
 Module* ProgramGraphBuilder::AddModule(const string& name) {

--- a/programl/graph/py/program_graph_builder_test.py
+++ b/programl/graph/py/program_graph_builder_test.py
@@ -27,7 +27,7 @@ def test_empty_proto():
   builder = program_graph_builder.ProgramGraphBuilder()
   with test.Raises(ValueError) as e_ctx:
     builder.Build()
-  assert "INSTRUCTION has no connections: `<root>`" == str(e_ctx.value)
+  assert "INSTRUCTION has no connections: `[external]`" == str(e_ctx.value)
 
 
 def test_add_empty_module():
@@ -75,7 +75,7 @@ def test_linear_statement_control_flow():
 
   assert len(builder.Build().node) == 3
 
-  assert builder.Build().node[builder.root].text == "<root>"
+  assert builder.Build().node[builder.root].text == "[external]"
   assert builder.Build().node[builder.root].type == node_pb2.Node.INSTRUCTION
 
   assert builder.Build().node[a].text == "a"

--- a/programl/ir/llvm/py/llvm_test.py
+++ b/programl/ir/llvm/py/llvm_test.py
@@ -52,7 +52,7 @@ def test_simple_ir():
   assert proto.module[0].name == "foo.c"
 
   assert len(proto.node) == 6
-  assert proto.node[0].text == "<root>"
+  assert proto.node[0].text == "[external]"
   assert proto.node[0].type == node_pb2.Node.INSTRUCTION
 
   assert proto.node[1].text == "add"

--- a/programl/test/data/program.pbtxt
+++ b/programl/test/data/program.pbtxt
@@ -20,7 +20,7 @@
 # first node.
 node {
   type: INSTRUCTION
-  text: "<root>"
+  text: "[external]"
 }
 # The instruction which adds a constant to a variable.
 node {


### PR DESCRIPTION
There is a minor discrepancy between the terminology in the
paper (external) and the code (root). [external] makes more sense and
is clearer.

github.com/ChrisCummins/ProGraML/issues/80