### PR TITLE
Disable strict graph checks by default

### DIFF
--- a/programl/cmd/llvm2graph.cc
+++ b/programl/cmd/llvm2graph.cc
@@ -59,6 +59,11 @@ DEFINE_bool(ignore_call_returns, false,
 DEFINE_int32(ir_list_index, 0,
              "If reading an IrList protocol buffer, use this value to index "
              "into the list.");
+DEFINE_bool(strict, false,
+            "Validate that the generated graph conforms to expectations of "
+            "what a graph should look like - i.e. the module is not empty, "
+            "every function contains instructions, and it does not contain "
+            "unreachable code.");
 
 StatusOr<programl::ProgramGraphOptions> GetProgramGraphOptionsFromFlags() {
   programl::ProgramGraphOptions options;
@@ -67,6 +72,9 @@ StatusOr<programl::ProgramGraphOptions> GetProgramGraphOptionsFromFlags() {
   }
   if (FLAGS_ignore_call_returns) {
     options.set_ignore_call_returns(true);
+  }
+  if (FLAGS_strict) {
+    options.set_strict(true);
   }
   return options;
 }

--- a/programl/cmd/tests/BUILD
+++ b/programl/cmd/tests/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+py_test(
+    name = "llvm2graph_strict_mode",
+    srcs = ["llvm2graph_strict_mode.py"],
+    data = [
+        "//programl/cmd:llvm2graph",
+        "//programl/test/data:module_with_unreachable_instructions",
+    ],
+    deps = [
+        "//third_party/py/labm8",
+    ],
+)

--- a/programl/cmd/tests/llvm2graph_strict_mode.py
+++ b/programl/cmd/tests/llvm2graph_strict_mode.py
@@ -1,0 +1,43 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end test that --strict flag on llvm2graph rejects invalid graphs."""
+import subprocess
+
+from labm8.py import bazelutil
+from labm8.py import test
+
+
+LLVM2GRAPH = bazelutil.DataPath("programl/programl/cmd/llvm2graph")
+
+
+# This IR file contains unreachable instructions, which will be rejected if
+# --strict mode is enabled.
+INVALID_MODULE = bazelutil.DataPath(
+    "programl/programl/test/data/module_with_unreachable_instructions.ll"
+)
+
+
+def test_invalid_module():
+  subprocess.check_call([str(LLVM2GRAPH), str(INVALID_MODULE)])
+
+
+def test_invalid_module_strict():
+  with test.Raises(subprocess.CalledProcessError):
+    subprocess.check_call([str(LLVM2GRAPH), str(INVALID_MODULE), "--strict"])
+
+
+if __name__ == '__main__':
+  test.Main()

--- a/programl/graph/BUILD
+++ b/programl/graph/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@labm8//labm8/cpp:logging",
         "@labm8//labm8/cpp:status",
+        "@labm8//labm8/cpp:status_macros",
         "@labm8//labm8/cpp:statusor",
         "@labm8//labm8/cpp:string",
     ],

--- a/programl/graph/BUILD
+++ b/programl/graph/BUILD
@@ -33,6 +33,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//programl/proto:program_graph_cc",
+        "//programl/proto:program_graph_options_cc",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@labm8//labm8/cpp:logging",

--- a/programl/graph/program_graph_builder.cc
+++ b/programl/graph/program_graph_builder.cc
@@ -24,7 +24,8 @@ namespace error = labm8::error;
 namespace programl {
 namespace graph {
 
-ProgramGraphBuilder::ProgramGraphBuilder() {
+ProgramGraphBuilder::ProgramGraphBuilder(const ProgramGraphOptions& options)
+    : options_(options) {
   // Create the graph root node.
   AddNode(Node::INSTRUCTION, "[external]");
 }

--- a/programl/graph/program_graph_builder.cc
+++ b/programl/graph/program_graph_builder.cc
@@ -17,6 +17,7 @@
 #include "programl/graph/program_graph_builder.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status.h"
+#include "labm8/cpp/status_macros.h"
 
 using labm8::Status;
 namespace error = labm8::error;
@@ -145,6 +146,13 @@ labm8::StatusOr<Edge*> ProgramGraphBuilder::AddCallEdge(const Node* source,
 }
 
 labm8::StatusOr<ProgramGraph> ProgramGraphBuilder::Build() {
+  if (options().strict()) {
+    RETURN_IF_ERROR(ValidateGraph());
+  }
+  return GetProgramGraph();
+}
+
+labm8::Status ProgramGraphBuilder::ValidateGraph() const {
   // Check that all nodes except the root are connected. The root is allowed to
   // have no connections in the case where it is an empty graph.
   if (!emptyModules_.empty()) {
@@ -164,7 +172,7 @@ labm8::StatusOr<ProgramGraph> ProgramGraphBuilder::Build() {
                   (*unconnectedNodes_.begin())->text());
   }
 
-  return GetProgramGraph();
+  return Status::OK;
 }
 
 void ProgramGraphBuilder::Clear() {

--- a/programl/graph/program_graph_builder.h
+++ b/programl/graph/program_graph_builder.h
@@ -25,6 +25,7 @@
 #include "labm8/cpp/statusor.h"
 #include "labm8/cpp/string.h"
 #include "programl/proto/program_graph.pb.h"
+#include "programl/proto/program_graph_options.pb.h"
 
 namespace programl {
 namespace graph {
@@ -46,7 +47,9 @@ namespace graph {
 //
 class ProgramGraphBuilder {
  public:
-  ProgramGraphBuilder();
+  ProgramGraphBuilder() : ProgramGraphBuilder(ProgramGraphOptions{}) {}
+
+  explicit ProgramGraphBuilder(const ProgramGraphOptions& options);
 
   // Construct a new function and return its number.
   Module* AddModule(const string& name);
@@ -85,6 +88,8 @@ class ProgramGraphBuilder {
   void Clear();
 
  protected:
+  inline const ProgramGraphOptions& options() const { return options_; }
+
   // Construct nodes.
 
   inline Node* AddNode(const Node::Type& type);
@@ -103,6 +108,8 @@ class ProgramGraphBuilder {
   ProgramGraph* GetMutableProgramGraph() { return &graph_; }
 
  private:
+  const ProgramGraphOptions options_;
+
   ProgramGraph graph_;
 
   // Get the index of an object in a repeated field lists.

--- a/programl/graph/program_graph_builder.h
+++ b/programl/graph/program_graph_builder.h
@@ -81,8 +81,11 @@ class ProgramGraphBuilder {
   // Return the graph protocol buffer.
   const ProgramGraph& GetProgramGraph() const { return graph_; }
 
-  // Validate the program graph and return it. Call Clear() if you wish to
+  // Return the program graph, and validate it first if strict option is set.
   [[nodiscard]] labm8::StatusOr<ProgramGraph> Build();
+
+  // Validate the program graph.
+  [[nodiscard]] labm8::Status ValidateGraph() const;
 
   // Reset builder state.
   void Clear();

--- a/programl/graph/py/BUILD
+++ b/programl/graph/py/BUILD
@@ -26,6 +26,7 @@ pybind_extension(
     srcs = ["program_graph_builder_pybind.cc"],
     deps = [
         "//programl/graph:program_graph_builder",
+        "//programl/proto:program_graph_options_cc",
     ],
 )
 
@@ -48,6 +49,7 @@ py_test(
         "//programl/proto:edge_py",
         "//programl/proto:node_py",
         "//programl/proto:program_graph_py",
+        "//programl/proto:program_graph_options_py",
         "//third_party/py/labm8",
     ],
 )

--- a/programl/graph/py/BUILD
+++ b/programl/graph/py/BUILD
@@ -36,6 +36,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//programl/proto:program_graph_py",
+        "//programl/proto:program_graph_options_py",
     ],
 )
 

--- a/programl/graph/py/program_graph_builder.py
+++ b/programl/graph/py/program_graph_builder.py
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This file defines a class for constructing program graphs."""
+from typing import Optional
+
 from programl.graph.py import program_graph_builder_pybind
 from programl.proto import program_graph_pb2
+from programl.proto.program_graph_options_pb2 import ProgramGraphOptions
 
 
 class ProgramGraphBuilder(program_graph_builder_pybind.ProgramGraphBuilder):
@@ -31,8 +34,12 @@ class ProgramGraphBuilder(program_graph_builder_pybind.ProgramGraphBuilder):
 
       graph = builder.Build().
 
-    After calling Build(), the object may be re-used.
-    """
+  After calling Build(), the object may be re-used.
+  """
+
+  def __init__(self, options: Optional[ProgramGraphOptions] = None):
+    options = options or ProgramGraphOptions()
+    super().__init__(options.SerializeToString())
 
   def Build(self) -> program_graph_pb2.ProgramGraph:
     proto = program_graph_pb2.ProgramGraph()

--- a/programl/graph/py/program_graph_builder_pybind.cc
+++ b/programl/graph/py/program_graph_builder_pybind.cc
@@ -16,35 +16,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <sstream>
+#include <string>
 #include "programl/graph/program_graph_builder.h"
+#include "programl/proto/program_graph_options.pb.h"
 #include "pybind11/pybind11.h"
 
 namespace py = pybind11;
 
 namespace programl {
 namespace graph {
+
+ProgramGraphOptions DeserializeOptions(const std::string& serializedOptions) {
+  ProgramGraphOptions options;
+  if (!options.ParseFromString(serializedOptions)) {
+    throw std::runtime_error("Failed to parse ProgramGraphOptions proto");
+  }
+  return options;
+}
+
+// A ProgramGraphBuilder class wrapper which adds a constructor for serialized options protos.
+class PyProgramGraphBuilder : public ProgramGraphBuilder {
+ public:
+  explicit PyProgramGraphBuilder(const std::string& serializedOptions) : ProgramGraphBuilder(DeserializeOptions(serializedOptions)) {}
+};
+
 PYBIND11_MODULE(program_graph_builder_pybind, m) {
   m.doc() = "A class for building program graphs";
 
-  py::class_<ProgramGraphBuilder>(m, "ProgramGraphBuilder")
-      .def(py::init<>())
+  py::class_<PyProgramGraphBuilder>(m, "ProgramGraphBuilder")
+      .def(py::init<const std::string&>())
       .def("_Build",
-           [&](ProgramGraphBuilder& builder) {
+           [&](PyProgramGraphBuilder& builder) {
              ProgramGraph graph = builder.Build().ValueOrException();
              std::stringstream str;
              graph.SerializeToOstream(&str);
              return py::bytes(str.str());
            })
-      .def("Clear", &ProgramGraphBuilder::Clear)
+      .def("Clear", &PyProgramGraphBuilder::Clear)
       .def("AddModule",
-           [&](ProgramGraphBuilder& builder, const string& name) {
+           [&](PyProgramGraphBuilder& builder, const string& name) {
              int index = builder.GetProgramGraph().module_size();
              builder.AddModule(name);
              return index;
            },
            py::arg("name"))
       .def("AddFunction",
-           [&](ProgramGraphBuilder& builder, const string& name, int module) {
+           [&](PyProgramGraphBuilder& builder, const string& name, int module) {
              const Module* mod = &builder.GetProgramGraph().module(module);
              int index = builder.GetProgramGraph().function_size();
              builder.AddFunction(name, mod);
@@ -52,7 +69,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            },
            py::arg("name"), py::arg("module"))
       .def("AddInstruction",
-           [&](ProgramGraphBuilder& builder, const string& text, int function) {
+           [&](PyProgramGraphBuilder& builder, const string& text, int function) {
              const Function* fn = &builder.GetProgramGraph().function(function);
              int index = builder.GetProgramGraph().node_size();
              builder.AddInstruction(text, fn);
@@ -60,7 +77,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            },
            py::arg("text"), py::arg("function"))
       .def("AddVariable",
-           [&](ProgramGraphBuilder& builder, const string& text, int function) {
+           [&](PyProgramGraphBuilder& builder, const string& text, int function) {
              const Function* fn = &builder.GetProgramGraph().function(function);
              int index = builder.GetProgramGraph().node_size();
              builder.AddVariable(text, fn);
@@ -68,7 +85,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            },
            py::arg("text"), py::arg("function"))
       .def("AddConstant",
-           [&](ProgramGraphBuilder& builder, const string& text) {
+           [&](PyProgramGraphBuilder& builder, const string& text) {
              int index = builder.GetProgramGraph().node_size();
              builder.AddConstant(text);
              return index;
@@ -76,7 +93,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            py::arg("text"))
 
       .def("AddControlEdge",
-           [&](ProgramGraphBuilder& builder, int source, int target,
+           [&](PyProgramGraphBuilder& builder, int source, int target,
                int position) {
              const Node* sourceNode = &builder.GetProgramGraph().node(source);
              const Node* targetNode = &builder.GetProgramGraph().node(target);
@@ -87,7 +104,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            py::arg("source"), py::arg("target"), py::arg("position"))
 
       .def("AddDataEdge",
-           [&](ProgramGraphBuilder& builder, int source, int target,
+           [&](PyProgramGraphBuilder& builder, int source, int target,
                int position) {
              const Node* sourceNode = &builder.GetProgramGraph().node(source);
              const Node* targetNode = &builder.GetProgramGraph().node(target);
@@ -98,7 +115,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            py::arg("source"), py::arg("target"), py::arg("position"))
 
       .def("AddCallEdge",
-           [&](ProgramGraphBuilder& builder, int source, int target) {
+           [&](PyProgramGraphBuilder& builder, int source, int target) {
              const Node* sourceNode = &builder.GetProgramGraph().node(source);
              const Node* targetNode = &builder.GetProgramGraph().node(target);
              builder.AddCallEdge(sourceNode, targetNode)
@@ -108,7 +125,7 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
            py::arg("source"), py::arg("target"))
 
       .def_property_readonly("root",
-                             [&](ProgramGraphBuilder& builder) { return 0; });
+                             [&](PyProgramGraphBuilder& builder) { return 0; });
 }
 
 }  // namespace graph

--- a/programl/ir/llvm/internal/program_graph_builder.cc
+++ b/programl/ir/llvm/internal/program_graph_builder.cc
@@ -94,7 +94,7 @@ labm8::StatusOr<BasicBlockEntryExit> ProgramGraphBuilder::VisitBasicBlock(
         // will be produced provide the information we want to capture.
       } else if (const auto* constant =
                      ::llvm::dyn_cast<::llvm::Constant>(value)) {
-        if (options_.instructions_only()) {
+        if (options().instructions_only()) {
           continue;
         }
         // If the operand is a constant value, insert a new entry into the map
@@ -103,7 +103,7 @@ labm8::StatusOr<BasicBlockEntryExit> ProgramGraphBuilder::VisitBasicBlock(
         constants_[constant].push_back({instructionMessage, position});
       } else if (const auto* operand =
                      ::llvm::dyn_cast<::llvm::Instruction>(value)) {
-        if (options_.instructions_only()) {
+        if (options().instructions_only()) {
           continue;
         }
         // We have an instruction operand which itself is another instruction.
@@ -137,7 +137,7 @@ labm8::StatusOr<BasicBlockEntryExit> ProgramGraphBuilder::VisitBasicBlock(
         dataEdgesToAdd->push_back({operand, variable});
       } else if (const auto* operand =
                      ::llvm::dyn_cast<::llvm::Argument>(value)) {
-        if (options_.instructions_only()) {
+        if (options().instructions_only()) {
           continue;
         }
         (*argumentConsumers)[operand].push_back({instructionMessage, position});
@@ -312,7 +312,7 @@ labm8::StatusOr<FunctionEntryExits> ProgramGraphBuilder::VisitFunction(
 Status ProgramGraphBuilder::AddCallSite(const Node* source,
                                         const FunctionEntryExits& target) {
   RETURN_IF_ERROR(AddCallEdge(source, target.first).status());
-  if (!options_.ignore_call_returns()) {
+  if (!options().ignore_call_returns()) {
     for (auto exitNode : target.second) {
       RETURN_IF_ERROR(AddCallEdge(exitNode, source).status());
     }

--- a/programl/ir/llvm/internal/program_graph_builder.h
+++ b/programl/ir/llvm/internal/program_graph_builder.h
@@ -65,8 +65,7 @@ using ArgumentConsumerMap =
 class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
  public:
   explicit ProgramGraphBuilder(const ProgramGraphOptions& options)
-      : programl::graph::ProgramGraphBuilder(),
-        options_(options),
+      : programl::graph::ProgramGraphBuilder(options),
         blockCount_(0){}
 
             [[nodiscard]] labm8::StatusOr<ProgramGraph> Build(
@@ -95,8 +94,6 @@ class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
   Node* AddLlvmConstant(const ::llvm::Constant* constant);
 
  private:
-  const ProgramGraphOptions options_;
-
   TextEncoder textEncoder_;
 
   int32_t blockCount_;

--- a/programl/proto/program_graph_options.proto
+++ b/programl/proto/program_graph_options.proto
@@ -27,6 +27,11 @@ option java_package = "com.programl";
 
 // Options used to generate a program graph.
 message ProgramGraphOptions {
+  // If set, the program graph builder will reject graphs where:
+  //  1. A module contains no nodes.
+  //  2. A function contains no nodes.
+  //  3. A node is unnconnected.
+  bool strict = 3;
   bool instructions_only = 1;
   bool ignore_call_returns = 2;
   int32 opt_level = 4;

--- a/programl/test/data/BUILD
+++ b/programl/test/data/BUILD
@@ -3082,3 +3082,9 @@ genrule(
     ),
     tools = ["//programl/cmd:analyze"],
 )
+
+filegroup(
+    name = "module_with_unreachable_instructions",
+    testonly = 1,
+    srcs = ["module_with_unreachable_instructions.ll"],
+)

--- a/programl/test/data/module_with_unreachable_instructions.ll
+++ b/programl/test/data/module_with_unreachable_instructions.ll
@@ -1,0 +1,246 @@
+
+%class.java_lang_Class = type { %cdv_ty.java_lang_Class*, i8*, { %class.java_lang_reflect_Constructor*, %class.java_lang_Class*, %class.java_lang_String*, %class.java_lang_ClassLoader*, %class.java_lang_ref_SoftReference*, i32, %class.sun_reflect_generics_repository_ClassRepository*, %class.jlang_runtime_Array*, %interface.java_util_Map*, %"class.java_lang_Class$AnnotationData"*, %class.sun_reflect_annotation_AnnotationType*, %"class.java_lang_ClassValue$ClassValueMap"* } }
+%cdv_ty.java_lang_Class = type opaque
+%class.java_lang_reflect_Constructor = type opaque
+%class.java_lang_String = type opaque
+%class.java_lang_ClassLoader = type opaque
+%class.java_lang_ref_SoftReference = type opaque
+%class.sun_reflect_generics_repository_ClassRepository = type opaque
+%class.jlang_runtime_Array = type opaque
+%interface.java_util_Map = type opaque
+%"class.java_lang_Class$AnnotationData" = type opaque
+%class.sun_reflect_annotation_AnnotationType = type opaque
+%"class.java_lang_ClassValue$ClassValueMap" = type opaque
+%cdv_ty.Fib = type { %class.java_lang_Class**, i8*, { i32, [2 x i8*] }*, { %class.java_lang_Object* (%class.java_lang_Object*)*, i1 (%class.java_lang_Object*, %class.java_lang_Object*)*, void (%class.java_lang_Object*)*, %class.java_lang_Class* (%class.java_lang_Object*)*, i32 (%class.java_lang_Object*)*, void (%class.java_lang_Object*)*, void (%class.java_lang_Object*)*, %class.java_lang_String* (%class.java_lang_Object*)*, void (%class.java_lang_Object*, i64)*, void (%class.java_lang_Object*, i64, i32)*, void (%class.java_lang_Object*)*, i32 (%class.Fib*, i32)* } }
+%class.java_lang_Object = type opaque
+%class.Fib = type { %cdv_ty.Fib*, i8*, {} }
+
+@Polyglot_Fib_class = global %class.java_lang_Class* null
+@Polyglot_Fib_class_id = global i8 0
+@Polyglot_java_lang_Object_class_id = external global i8
+@Polyglot_Fib_rtti = linkonce_odr global { i32, [2 x i8*] } { i32 2, [2 x i8*] [i8* @Polyglot_Fib_class_id, i8* @Polyglot_java_lang_Object_class_id] }
+@jni_JNIEnv = external global i8
+@0 = private constant [4 x i8] c"fib\00"
+@1 = private constant [5 x i8] c"(I)I\00"
+@Polyglot_native_int = external global %class.java_lang_Class*
+@2 = private global [1 x i8*] [i8* bitcast (%class.java_lang_Class** @Polyglot_native_int to i8*)]
+@3 = private constant [7 x i8] c"<init>\00"
+@4 = private constant [4 x i8] c"()V\00"
+@5 = private global [0 x i8*] zeroinitializer
+@6 = private constant [4 x i8] c"Fib\00"
+@Polyglot_java_lang_Object_class = external global %class.java_lang_Class*
+@Polyglot_Fib_cdv = global %cdv_ty.Fib { %class.java_lang_Class** @Polyglot_Fib_class, i8* null, { i32, [2 x i8*] }* @Polyglot_Fib_rtti, { %class.java_lang_Object* (%class.java_lang_Object*)*, i1 (%class.java_lang_Object*, %class.java_lang_Object*)*, void (%class.java_lang_Object*)*, %class.java_lang_Class* (%class.java_lang_Object*)*, i32 (%class.java_lang_Object*)*, void (%class.java_lang_Object*)*, void (%class.java_lang_Object*)*, %class.java_lang_String* (%class.java_lang_Object*)*, void (%class.java_lang_Object*, i64)*, void (%class.java_lang_Object*, i64, i32)*, void (%class.java_lang_Object*)*, i32 (%class.Fib*, i32)* } { %class.java_lang_Object* (%class.java_lang_Object*)* @Polyglot_java_lang_Object_clone__, i1 (%class.java_lang_Object*, %class.java_lang_Object*)* @Polyglot_java_lang_Object_equals__Ljava_lang_Object_2, void (%class.java_lang_Object*)* @Polyglot_java_lang_Object_finalize__, %class.java_lang_Class* (%class.java_lang_Object*)* @Polyglot_java_lang_Object_getClass__, i32 (%class.java_lang_Object*)* @Polyglot_java_lang_Object_hashCode__, void (%class.java_lang_Object*)* @Polyglot_java_lang_Object_notify__, void (%class.java_lang_Object*)* @Polyglot_java_lang_Object_notifyAll__, %class.java_lang_String* (%class.java_lang_Object*)* @Polyglot_java_lang_Object_toString__, void (%class.java_lang_Object*, i64)* @Polyglot_java_lang_Object_wait__J, void (%class.java_lang_Object*, i64, i32)* @Polyglot_java_lang_Object_wait__JI, void (%class.java_lang_Object*)* @Polyglot_java_lang_Object_wait__, i32 (%class.Fib*, i32)* @Polyglot_Fib_fib__I } }
+@7 = private constant [0 x %class.java_lang_Class**] zeroinitializer
+@8 = private global [0 x { i8*, i32, i32, i8*, i8* }] zeroinitializer
+@9 = private global [0 x { i8*, i8*, i8*, i32, i8* }] zeroinitializer
+@10 = private global [2 x { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }] [{ i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i32 ptrtoint (i32 (%class.Fib*, i32)** getelementptr (%cdv_ty.Fib, %cdv_ty.Fib* null, i32 0, i32 3, i32 11) to i32), i8* bitcast (i32 (%class.Fib*, i32)* @Polyglot_Fib_fib__I to i8*), i8* bitcast (i32 (i8*, i64*)* @"Jni_trampoline_(LI)I" to i8*), i8* null, i32 0, i32 1, i8* bitcast (%class.java_lang_Class** @Polyglot_native_int to i8*), i32 1, i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @2, i32 0, i32 0) }, { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0), i32 -2, i8* bitcast (void (%class.Fib*)* @Polyglot_Fib_Fib__ to i8*), i8* bitcast (void (i8*, i64*)* @"Jni_trampoline_(L)V" to i8*), i8* null, i32 0, i32 1, i8* bitcast (%class.java_lang_Class** @Polyglot_Fib_class to i8*), i32 0, i8** getelementptr inbounds ([0 x i8*], [0 x i8*]* @5, i32 0, i32 0) }]
+@Polyglot_Fib_class_info = private constant { i8*, %class.java_lang_Class**, i8*, i64, i8, i32, %class.java_lang_Class***, i32, { i8*, i32, i32, i8*, i8* }*, i32, { i8*, i8*, i8*, i32, i8* }*, i32, { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @6, i32 0, i32 0), %class.java_lang_Class** @Polyglot_java_lang_Object_class, i8* bitcast (%cdv_ty.Fib* @Polyglot_Fib_cdv to i8*), i64 ptrtoint (%class.Fib* getelementptr (%class.Fib, %class.Fib* null, i32 1) to i64), i8 0, i32 0, %class.java_lang_Class*** getelementptr inbounds ([0 x %class.java_lang_Class**], [0 x %class.java_lang_Class**]* @7, i32 0, i32 0), i32 0, { i8*, i32, i32, i8*, i8* }* getelementptr inbounds ([0 x { i8*, i32, i32, i8*, i8* }], [0 x { i8*, i32, i32, i8*, i8* }]* @8, i32 0, i32 0), i32 0, { i8*, i8*, i8*, i32, i8* }* getelementptr inbounds ([0 x { i8*, i8*, i8*, i32, i8* }], [0 x { i8*, i8*, i8*, i32, i8* }]* @9, i32 0, i32 0), i32 2, { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }* getelementptr inbounds ([2 x { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }], [2 x { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }]* @10, i32 0, i32 0) }
+@Polyglot_java_lang_Class_cdv = external global %cdv_ty.java_lang_Class
+
+declare i8* @__GC_malloc(i64)
+
+define linkonce_odr i32 @"Jni_trampoline_(LI)I"(i8*, i64*) !dbg !4 {
+entry:
+  br label %body, !dbg !9
+
+body:                                             ; preds = %entry
+  %gep = getelementptr i64, i64* %1, i32 0, !dbg !9
+  %cast.arg.0 = bitcast i64* %gep to %class.java_lang_Object**, !dbg !9
+  %load.arg.0 = load %class.java_lang_Object*, %class.java_lang_Object** %cast.arg.0, !dbg !9
+  %gep1 = getelementptr i64, i64* %1, i32 1, !dbg !9
+  %cast.arg.1 = bitcast i64* %gep1 to i32*, !dbg !9
+  %load.arg.1 = load i32, i32* %cast.arg.1, !dbg !9
+  %cast.func = bitcast i8* %0 to i32 (%class.java_lang_Object*, i32)*, !dbg !9
+  %call = call i32 %cast.func(%class.java_lang_Object* %load.arg.0, i32 %load.arg.1), !dbg !9
+  ret i32 %call, !dbg !9
+}
+
+define i32 @Polyglot_Fib_fib__I(%class.Fib*, i32) !dbg !10 {
+entry:
+  %x = alloca i32, !dbg !15
+  br label %body, !dbg !15
+
+body:                                             ; preds = %entry
+  call void @llvm.dbg.declare(metadata i32* %x, metadata !16, metadata !17), !dbg !18
+  store i32 %1, i32* %x, !dbg !15
+  %load.x = load i32, i32* %x, !dbg !19
+  switch i32 %load.x, label %switch.case2 [
+    i32 0, label %switch.case
+    i32 1, label %switch.case1
+  ], !dbg !20
+
+switch.case:                                      ; preds = %body
+  ret i32 0, !dbg !21
+
+switch.case1:                                     ; preds = %body
+  ret i32 1, !dbg !22
+
+switch.case2:                                     ; preds = %body
+  %load.x3 = load i32, i32* %x, !dbg !23
+  %ibinop = sub i32 %load.x3, 1, !dbg !23
+  %gep = getelementptr %class.Fib, %class.Fib* %0, i32 0, i32 0, !dbg !24
+  %load.dv = load %cdv_ty.Fib*, %cdv_ty.Fib** %gep, !dbg !24
+  %gep4 = getelementptr %cdv_ty.Fib, %cdv_ty.Fib* %load.dv, i32 0, i32 3, i32 11, !dbg !24
+  %load.dv.method = load i32 (%class.Fib*, i32)*, i32 (%class.Fib*, i32)** %gep4, !dbg !24
+  %call = call i32 %load.dv.method(%class.Fib* %0, i32 %ibinop), !dbg !24
+  %load.x5 = load i32, i32* %x, !dbg !25
+  %ibinop6 = sub i32 %load.x5, 2, !dbg !25
+  %gep7 = getelementptr %class.Fib, %class.Fib* %0, i32 0, i32 0, !dbg !26
+  %load.dv8 = load %cdv_ty.Fib*, %cdv_ty.Fib** %gep7, !dbg !26
+  %gep9 = getelementptr %cdv_ty.Fib, %cdv_ty.Fib* %load.dv8, i32 0, i32 3, i32 11, !dbg !26
+  %load.dv.method10 = load i32 (%class.Fib*, i32)*, i32 (%class.Fib*, i32)** %gep9, !dbg !26
+  %call11 = call i32 %load.dv.method10(%class.Fib* %0, i32 %ibinop6), !dbg !26
+  %ibinop12 = add i32 %call, %call11, !dbg !24
+  ret i32 %ibinop12, !dbg !27
+
+switch.end:                                       ; No predecessors!
+  unreachable, !dbg !15
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+declare %class.java_lang_Object* @Polyglot_java_lang_Object_clone__(%class.java_lang_Object*)
+
+declare i1 @Polyglot_java_lang_Object_equals__Ljava_lang_Object_2(%class.java_lang_Object*, %class.java_lang_Object*)
+
+declare void @Polyglot_java_lang_Object_finalize__(%class.java_lang_Object*)
+
+declare %class.java_lang_Class* @Polyglot_java_lang_Object_getClass__(%class.java_lang_Object*)
+
+declare i32 @Polyglot_java_lang_Object_hashCode__(%class.java_lang_Object*)
+
+declare void @Polyglot_java_lang_Object_notify__(%class.java_lang_Object*)
+
+declare void @Polyglot_java_lang_Object_notifyAll__(%class.java_lang_Object*)
+
+declare %class.java_lang_String* @Polyglot_java_lang_Object_toString__(%class.java_lang_Object*)
+
+declare void @Polyglot_java_lang_Object_wait__J(%class.java_lang_Object*, i64)
+
+declare void @Polyglot_java_lang_Object_wait__JI(%class.java_lang_Object*, i64, i32)
+
+declare void @Polyglot_java_lang_Object_wait__(%class.java_lang_Object*)
+
+define linkonce_odr void @"Jni_trampoline_(L)V"(i8*, i64*) !dbg !28 {
+entry:
+  br label %body, !dbg !29
+
+body:                                             ; preds = %entry
+  %gep = getelementptr i64, i64* %1, i32 0, !dbg !29
+  %cast.arg.0 = bitcast i64* %gep to %class.java_lang_Object**, !dbg !29
+  %load.arg.0 = load %class.java_lang_Object*, %class.java_lang_Object** %cast.arg.0, !dbg !29
+  %cast.func = bitcast i8* %0 to void (%class.java_lang_Object*)*, !dbg !29
+  call void %cast.func(%class.java_lang_Object* %load.arg.0), !dbg !29
+  ret void, !dbg !29
+}
+
+define void @Polyglot_Fib_Fib__(%class.Fib*) !dbg !30 {
+entry:
+  br label %body, !dbg !33
+
+body:                                             ; preds = %entry
+  %call = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !33
+  call void @jni_MonitorEnter(i8* @jni_JNIEnv, %class.java_lang_Object* %call), !dbg !33
+  %class = load %class.java_lang_Class*, %class.java_lang_Class** @Polyglot_Fib_class, !dbg !33
+  %class.null = icmp eq %class.java_lang_Class* %class, null, !dbg !33
+  br i1 %class.null, label %load.class, label %continue, !dbg !33
+
+load.class:                                       ; preds = %body
+  %call1 = call %class.java_lang_Class* @Polyglot_Fib_load_class(), !dbg !33
+  br label %continue, !dbg !33
+
+continue:                                         ; preds = %load.class, %body
+  %call2 = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !33
+  call void @jni_MonitorExit(i8* @jni_JNIEnv, %class.java_lang_Object* %call2), !dbg !33
+  %cast.erasure = bitcast %class.Fib* %0 to %class.java_lang_Object*, !dbg !34
+  call void @Polyglot_java_lang_Object_Object__(%class.java_lang_Object* %cast.erasure), !dbg !34
+  ret void, !dbg !33
+}
+
+declare %class.java_lang_Object* @getGlobalMutexObject()
+
+declare void @jni_MonitorEnter(i8*, %class.java_lang_Object*)
+
+define %class.java_lang_Class* @Polyglot_Fib_load_class() !dbg !35 {
+entry:
+  br label %body, !dbg !37
+
+body:                                             ; preds = %entry
+  %call = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !37
+  call void @jni_MonitorEnter(i8* @jni_JNIEnv, %class.java_lang_Object* %call), !dbg !37
+  %call1 = call i8* @__GC_malloc(i64 ptrtoint (%class.java_lang_Class* getelementptr (%class.java_lang_Class, %class.java_lang_Class* null, i32 1) to i64)), !dbg !37
+  %cast = bitcast i8* %call1 to %class.java_lang_Class*, !dbg !37
+  store %class.java_lang_Class* %cast, %class.java_lang_Class** @Polyglot_Fib_class, !dbg !37
+  %gep = getelementptr %class.java_lang_Class, %class.java_lang_Class* %cast, i32 0, i32 0, !dbg !37
+  store %cdv_ty.java_lang_Class* @Polyglot_java_lang_Class_cdv, %cdv_ty.java_lang_Class** %gep, !dbg !37
+  %call2 = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !37
+  call void @jni_MonitorEnter(i8* @jni_JNIEnv, %class.java_lang_Object* %call2), !dbg !37
+  %class = load %class.java_lang_Class*, %class.java_lang_Class** @Polyglot_java_lang_Object_class, !dbg !37
+  %class.null = icmp eq %class.java_lang_Class* %class, null, !dbg !37
+  br i1 %class.null, label %load.class, label %continue, !dbg !37
+
+load.class:                                       ; preds = %body
+  %call3 = call %class.java_lang_Class* @Polyglot_java_lang_Object_load_class(), !dbg !37
+  br label %continue, !dbg !37
+
+continue:                                         ; preds = %load.class, %body
+  %call4 = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !37
+  call void @jni_MonitorExit(i8* @jni_JNIEnv, %class.java_lang_Object* %call4), !dbg !37
+  call void @RegisterJavaClass(%class.java_lang_Class* %cast, { i8*, %class.java_lang_Class**, i8*, i64, i8, i32, %class.java_lang_Class***, i32, { i8*, i32, i32, i8*, i8* }*, i32, { i8*, i8*, i8*, i32, i8* }*, i32, { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }* }* @Polyglot_Fib_class_info), !dbg !37
+  %call5 = call %class.java_lang_Object* @getGlobalMutexObject(), !dbg !37
+  call void @jni_MonitorExit(i8* @jni_JNIEnv, %class.java_lang_Object* %call5), !dbg !37
+  ret %class.java_lang_Class* %cast, !dbg !37
+}
+
+declare void @jni_MonitorExit(i8*, %class.java_lang_Object*)
+
+declare void @Polyglot_java_lang_Object_Object__(%class.java_lang_Object*)
+
+declare %class.java_lang_Class* @Polyglot_java_lang_Object_load_class()
+
+declare void @RegisterJavaClass(%class.java_lang_Class*, { i8*, %class.java_lang_Class**, i8*, i64, i8, i32, %class.java_lang_Class***, i32, { i8*, i32, i32, i8*, i8* }*, i32, { i8*, i8*, i8*, i32, i8* }*, i32, { i8*, i8*, i32, i8*, i8*, i8*, i32, i32, i8*, i32, i8** }* }*)
+
+attributes #0 = { nounwind readnone speculatable }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_Java, file: !1, producer: "JLang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "fib.java", directory: "/mnt/c/Users/d067621/OneDrive - SAP SE/Documents/Research/IVAN")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = distinct !DISubprogram(name: "Jni_trampoline_(LI)I", linkageName: "Jni_trampoline_(LI)I", scope: !1, file: !1, line: 3, type: !5, isLocal: false, isDefinition: true, scopeLine: 3, flags: DIFlagPrototyped, isOptimized: false, unit: !0)
+!5 = !DISubroutineType(types: !6)
+!6 = !{!7, !8}
+!7 = !DIBasicType(name: "void*", size: 64, encoding: DW_ATE_address)
+!8 = !DIBasicType(name: "jvalue*", size: 64, encoding: DW_ATE_address)
+!9 = !DILocation(line: 3, column: 15, scope: !4)
+!10 = distinct !DISubprogram(name: "Fib#fib(int)", linkageName: "Polyglot_Fib_fib__I", scope: !1, file: !1, line: 3, type: !11, isLocal: false, isDefinition: true, scopeLine: 3, flags: DIFlagPrototyped, isOptimized: false, unit: !0)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13, !14}
+!13 = !DICompositeType(tag: DW_TAG_structure_type, name: "Fib", file: !1, line: 2)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 3, column: 15, scope: !10)
+!16 = !DILocalVariable(name: "x", scope: !10, file: !1, line: 3, type: !14)
+!17 = !DIExpression()
+!18 = !DILocation(line: 3, column: 19, scope: !10)
+!19 = !DILocation(line: 4, column: 15, scope: !10)
+!20 = !DILocation(line: 4, column: 8, scope: !10)
+!21 = !DILocation(line: 6, column: 16, scope: !10)
+!22 = !DILocation(line: 8, column: 16, scope: !10)
+!23 = !DILocation(line: 10, column: 27, scope: !10)
+!24 = !DILocation(line: 10, column: 23, scope: !10)
+!25 = !DILocation(line: 10, column: 40, scope: !10)
+!26 = !DILocation(line: 10, column: 36, scope: !10)
+!27 = !DILocation(line: 10, column: 16, scope: !10)
+!28 = distinct !DISubprogram(name: "Jni_trampoline_(L)V", linkageName: "Jni_trampoline_(L)V", scope: !1, file: !1, line: 2, type: !5, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: false, unit: !0)
+!29 = !DILocation(line: 2, column: 17, scope: !28)
+!30 = distinct !DISubprogram(name: "Fib#Fib()", linkageName: "Polyglot_Fib_Fib__", scope: !1, file: !1, line: 2, type: !31, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: false, unit: !0)
+!31 = !DISubroutineType(types: !32)
+!32 = !{!13}
+!33 = !DILocation(line: 2, column: 17, scope: !30)
+!34 = !DILocation(line: 2, column: 7, scope: !30)
+!35 = distinct !DISubprogram(name: "load_Fib", linkageName: "Polyglot_Fib_load_class", scope: !1, file: !1, line: 2, type: !36, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: false, unit: !0)
+!36 = !DISubroutineType(types: !2)
+!37 = !DILocation(line: 2, column: 7, scope: !35)


### PR DESCRIPTION
The strict graph checking (#87) is now disabled by default, and can be enabled using:

```
$ llvm2graph --strict <args...>
```