### PR TITLE
Update dependencies: networkx, scipy, scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ gast==0.2.2. # Dependency of tensorflow.
 GPUtil==1.4.0
 Keras==2.3.1
 kiwisolver==1.0.1  # Needed by matplotlib.
+joblib>=0.16.0  # Needed by scikit-learn
 matplotlib==2.2.0rc1
-networkx==2.2
+networkx>=2.4
 numpy==1.16.4
 pandas==0.24.1
 pathlib==1.0.1
@@ -15,8 +16,8 @@ pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2018.3
 PyYAML==4.2b4
-scikit-learn==0.20.3
-scipy==1.2.1
+scikit-learn>=0.23.2
+scipy>=1.5.2
 seaborn==0.9.0
 tensorflow>=1.14.0
 torch>=1.3.0

--- a/third_party/py/scikit_learn/BUILD
+++ b/third_party/py/scikit_learn/BUILD
@@ -11,6 +11,7 @@ py_library(
     srcs = ["//third_party/py:empty.py"],
     deps = [
         requirement("scikit-learn"),
+        requirement("joblib"),
         "//third_party/py/scipy",
     ],
 )


### PR DESCRIPTION
Python 3.8 introduced some failures in the python pypi dependencies:

scipy:

    $ bazel test //programl/models:rolling_results_test

    ImportError: dlopen(${bazelroot}/bin/programl/test/benchmarks/benchmark_dataflow_analyses.runfiles/programl_requirements_pypi__scipy_1_2_1/scipy/linalg/cython_lapack.cpython-38-darwin.so, 2): Symbol not found: _cbbcsd_
      Referenced from: ${bazelroot}/bin/programl/test/benchmarks/benchmark_dataflow_analyses.runfiles/programl_requirements_pypi__scipy_1_2_1/scipy/linalg/cython_lapack.cpython-38-darwin.so
      Expected in: flat namespace

scikit-learn:

    $ bazel test //programl/test/benchmarks:benchmark_dataflow_analyses

      File "${bazelroot}/bin/programl/models/rolling_results_test.runfiles/programl_requirements_pypi__scikit_learn_0_20_3/sklearn/externals/joblib/externals/cloudpickle/cloudpickle.py", line 148, in _make_cell_set_template_code
        return types.CodeType(
    TypeError: an integer is required (got type bytes)

networkx:

    ${bazelroot}/bin/programl/cmd/inst2vec.runfiles/programl_requirements_pypi__networkx_2_2/networkx/drawing/nx_pydot.py:210: SyntaxWarning: "is" with a literal. Did you mean "=="?

Update those packages to the versions to maintain support on Python 3.8.

github.com/ChrisCummins/ProGraML/issues/76