### PR TITLE
Enforce a consistent C++ code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,15 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  cpp:
+    name: C++
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: clang-format
+        uses: DoozyX/clang-format-lint-action@v0.8
+        with:
+          clangFormatVersion: 10

--- a/programl/cmd/analyze.cc
+++ b/programl/cmd/analyze.cc
@@ -46,8 +46,7 @@ int main(int argc, char** argv) {
   programl::util::ParseStdinOrDie(&graph);
 
   programl::ProgramGraphFeaturesList featuresList;
-  Status status =
-      programl::graph::analysis::RunAnalysis(argv[1], graph, &featuresList);
+  Status status = programl::graph::analysis::RunAnalysis(argv[1], graph, &featuresList);
   if (!status.ok()) {
     LOG(ERROR) << status.error_message();
     return 4;

--- a/programl/cmd/graph2cdfg.cc
+++ b/programl/cmd/graph2cdfg.cc
@@ -13,12 +13,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "labm8/cpp/app.h"
 #include "programl/graph/format/cdfg.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/util/stdin_fmt.h"
 #include "programl/util/stdout_fmt.h"
-
-#include "labm8/cpp/app.h"
 
 const char* usage =
     R"(Convert a ProgramGraph message to a Control and Data Flow Graph (CDFG).

--- a/programl/cmd/graph2dot.cc
+++ b/programl/cmd/graph2dot.cc
@@ -13,11 +13,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "labm8/cpp/app.h"
 #include "programl/graph/format/graphviz_converter.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/util/stdin_fmt.h"
-
-#include "labm8/cpp/app.h"
 
 const char* usage = R"(Convert a ProgramGraph message to GraphViz dot.
 
@@ -63,8 +62,7 @@ int main(int argc, char** argv) {
   ProgramGraph graph;
   util::ParseStdinOrDie(&graph);
 
-  Status status =
-      SerializeGraphVizToString(graph, &std::cout, label, nodeFeatureName);
+  Status status = SerializeGraphVizToString(graph, &std::cout, label, nodeFeatureName);
   if (!status.ok()) {
     std::cerr << "fatal: " << status.error_message() << std::endl;
     return 2;

--- a/programl/cmd/graph2json.cc
+++ b/programl/cmd/graph2json.cc
@@ -13,13 +13,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <iomanip>
+
+#include "labm8/cpp/app.h"
 #include "programl/graph/format/node_link_graph.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/util/stdin_fmt.h"
-
-#include "labm8/cpp/app.h"
-
-#include <iomanip>
 
 const char* usage = R"(Convert a ProgramGraph message to JSON node link graph.
 
@@ -43,8 +42,7 @@ int main(int argc, char** argv) {
   programl::util::ParseStdinOrDie(&graph);
 
   auto nodeLinkGraph = json({});
-  Status status = programl::graph::format::ProgramGraphToNodeLinkGraph(
-      graph, &nodeLinkGraph);
+  Status status = programl::graph::format::ProgramGraphToNodeLinkGraph(graph, &nodeLinkGraph);
   if (!status.ok()) {
     std::cerr << "fatal: failed to convert ProgramGraph to node link graph ("
               << status.error_message() << ')' << std::endl;

--- a/programl/cmd/graph2seq.cc
+++ b/programl/cmd/graph2seq.cc
@@ -35,8 +35,8 @@ int main(int argc, char** argv) {
   programl::util::ParseStdinOrDie(&graph);
 
   programl::NodeIndexList serialized;
-  programl::graph::format::SerializeInstructionsInProgramGraph(
-      graph, &serialized, /*maxNodes=*/1000000);
+  programl::graph::format::SerializeInstructionsInProgramGraph(graph, &serialized,
+                                                               /*maxNodes=*/1000000);
   programl::util::WriteStdout(serialized);
 
   return 0;

--- a/programl/cmd/llvm2graph.cc
+++ b/programl/cmd/llvm2graph.cc
@@ -21,14 +21,13 @@
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/statusor.h"
 #include "labm8/cpp/strutil.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/SourceMgr.h"
 #include "programl/ir/llvm/llvm.h"
 #include "programl/proto/ir.pb.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_options.pb.h"
 #include "programl/util/stdout_fmt.h"
-
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/SourceMgr.h"
 
 using labm8::Status;
 using labm8::StatusOr;
@@ -52,8 +51,7 @@ and the IR at position --ir_list_index (zero-based) is used:
 
   $ llvm2graph /path/to/list.IrList.pb --ir_list_index=2)";
 
-DEFINE_bool(instructions_only, false,
-            "Include only instructions in the generated program graph.");
+DEFINE_bool(instructions_only, false, "Include only instructions in the generated program graph.");
 DEFINE_bool(ignore_call_returns, false,
             "Include only instructions in the generated program graph.");
 DEFINE_int32(ir_list_index, 0,
@@ -85,8 +83,7 @@ StatusOr<programl::ProgramGraphOptions> GetProgramGraphOptionsFromFlags() {
 //   * if '.IrList.pb' suffix, read IrList protocol buffer and return index
 //   --ir_list_index;
 //   * else read text file.
-llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> GetInputAsBuffer(
-    const string& filename) {
+llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> GetInputAsBuffer(const string& filename) {
   if (labm8::HasSuffixString(filename, ".IrList.pb")) {
     std::ifstream file(filename);
     programl::IrList irList;
@@ -138,8 +135,8 @@ int main(int argc, char** argv) {
   }
 
   programl::ProgramGraph graph;
-  Status status = programl::ir::llvm::BuildProgramGraph(*buffer.get(), &graph,
-                                                        options.ValueOrDie());
+  Status status =
+      programl::ir::llvm::BuildProgramGraph(*buffer.get(), &graph, options.ValueOrDie());
   if (!status.ok()) {
     LOG(ERROR) << status.error_message();
     return 2;

--- a/programl/cmd/pbq.cc
+++ b/programl/cmd/pbq.cc
@@ -155,9 +155,7 @@ int main(int argc, char** argv) {
     const auto featuresList = ReadStdin<programl::ProgramGraphFeaturesList>();
     size_t nodeFeaturesCount = 0;
     for (int i = 0; i < featuresList.graph_size(); ++i) {
-      const auto& it =
-          featuresList.graph(i).node_features().feature_list().find(
-              "data_flow_value");
+      const auto& it = featuresList.graph(i).node_features().feature_list().find("data_flow_value");
       if (it != featuresList.graph(i).node_features().feature_list().end()) {
         nodeFeaturesCount += it->second.feature_size();
       }

--- a/programl/cmd/xla2graph.cc
+++ b/programl/cmd/xla2graph.cc
@@ -15,19 +15,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <fstream>
+#include <sstream>
+#include <streambuf>
+
 #include "labm8/cpp/app.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/statusor.h"
 #include "labm8/cpp/string.h"
 #include "programl/ir/xla/hlo_module_graph_builder.h"
-
 #include "programl/util/stdin_fmt.h"
 #include "tensorflow/compiler/xla/service/hlo.pb.h"
-
-#include <fstream>
-#include <sstream>
-#include <streambuf>
 
 static const char* usage = R"(Generate program graph from a HLO module.
 
@@ -65,8 +64,7 @@ void ParseInputOrDie(const string& filename, ProtocolBuffer* message) {
   str.reserve(file.tellg());
   file.seekg(0, std::ios::beg);
 
-  str.assign((std::istreambuf_iterator<char>(file)),
-             std::istreambuf_iterator<char>());
+  str.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
 
   if (!message->ParseFromString(str)) {
     LOG(ERROR) << "Failed to parse proto file: " << filename;

--- a/programl/graph/analysis/analysis.cc
+++ b/programl/graph/analysis/analysis.cc
@@ -48,8 +48,7 @@ Status RunAnalysis(const string& analysisName, const ProgramGraph& graph,
   } else if (analysisName == "subexpressions") {
     return Run<DatadepAnalysis>(graph, featuresList);
   } else {
-    return Status(error::Code::INVALID_ARGUMENT, "Invalid analysis: {}",
-                  analysisName);
+    return Status(error::Code::INVALID_ARGUMENT, "Invalid analysis: {}", analysisName);
   }
 }
 

--- a/programl/graph/analysis/data_flow_pass.cc
+++ b/programl/graph/analysis/data_flow_pass.cc
@@ -37,8 +37,7 @@ namespace {
 // Example output:
 //    0: [1, 2, 3]
 //    2: [3, 4]
-std::ostream& AdjacencyListToOstream(std::ostream& os,
-                                     const vector<vector<int>>& adjacencies) {
+std::ostream& AdjacencyListToOstream(std::ostream& os, const vector<vector<int>>& adjacencies) {
   for (int i = 0; i < adjacencies.size(); ++i) {
     if (!adjacencies[i].size()) {
       continue;
@@ -82,8 +81,7 @@ std::ostream& operator<<(std::ostream& os, const AdjacencyLists& dt) {
   return os;
 }
 
-const AdjacencyLists& DataFlowPass::ComputeAdjacencies(
-    const AdjacencyListOptions& options) {
+const AdjacencyLists& DataFlowPass::ComputeAdjacencies(const AdjacencyListOptions& options) {
   if (options.control) {
     adjacencies_.control.reserve(graph().node_size());
     for (int i = 0; i < graph().node_size(); ++i) {
@@ -132,8 +130,7 @@ const AdjacencyLists& DataFlowPass::ComputeAdjacencies(
         adjacencies_.reverse_data[edge.target()].push_back(edge.source());
       }
       if (options.reverse_data_positions) {
-        adjacencies_.reverse_data_positions[edge.target()].push_back(
-            edge.position());
+        adjacencies_.reverse_data_positions[edge.target()].push_back(edge.position());
       }
     }
   }
@@ -148,15 +145,13 @@ Status RoodNodeDataFlowAnalysis::Run(ProgramGraphFeaturesList* featuresList) {
 
   vector<int> rootNodes = GetEligibleRootNodes();
   if (!rootNodes.size()) {
-    return Status(error::Code::FAILED_PRECONDITION,
-                  "No eligible root nodes in graph with {} nodes",
+    return Status(error::Code::FAILED_PRECONDITION, "No eligible root nodes in graph with {} nodes",
                   graph().node_size());
   }
-  std::shuffle(rootNodes.begin(), rootNodes.end(),
-               std::default_random_engine(seed()));
+  std::shuffle(rootNodes.begin(), rootNodes.end(), std::default_random_engine(seed()));
 
-  int numRoots = std::min(static_cast<int>(ceil(rootNodes.size() / 10.0)),
-                          max_instances_per_graph());
+  int numRoots =
+      std::min(static_cast<int>(ceil(rootNodes.size() / 10.0)), max_instances_per_graph());
   for (int i = 0; i < numRoots; ++i) {
     ProgramGraphFeatures features;
     RETURN_IF_ERROR(RunOne(rootNodes[i], &features));
@@ -168,10 +163,8 @@ Status RoodNodeDataFlowAnalysis::Run(ProgramGraphFeaturesList* featuresList) {
 
 Status RoodNodeDataFlowAnalysis::Init() { return Status::OK; }
 
-void AddNodeFeature(ProgramGraphFeatures* features, const string& name,
-                    const Feature& value) {
-  (*(*features->mutable_node_features()->mutable_feature_list())[name]
-        .add_feature()) = value;
+void AddNodeFeature(ProgramGraphFeatures* features, const string& name, const Feature& value) {
+  (*(*features->mutable_node_features()->mutable_feature_list())[name].add_feature()) = value;
 }
 
 vector<int> GetInstructionsInFunctionsNodeIndices(const ProgramGraph& graph) {

--- a/programl/graph/analysis/data_flow_pass.h
+++ b/programl/graph/analysis/data_flow_pass.h
@@ -49,11 +49,9 @@ struct AdjacencyLists {
 // Base class for implementing data flow analysis passes.
 class DataFlowPass {
  public:
-  explicit DataFlowPass(const ProgramGraph& graph)
-      : graph_(graph){}
+  explicit DataFlowPass(const ProgramGraph& graph) : graph_(graph) {}
 
-            [[nodiscard]] virtual labm8::Status
-        Run(ProgramGraphFeaturesList * featuresList) = 0;
+  [[nodiscard]] virtual labm8::Status Run(ProgramGraphFeaturesList* featuresList) = 0;
 
   const ProgramGraph& graph() const { return graph_; }
 
@@ -72,8 +70,7 @@ class DataFlowPass {
 // selecting different root nodes from the set of elligible roots.
 class RoodNodeDataFlowAnalysis : public DataFlowPass {
  public:
-  RoodNodeDataFlowAnalysis(const ProgramGraph& graph)
-      : RoodNodeDataFlowAnalysis(graph, 10) {}
+  RoodNodeDataFlowAnalysis(const ProgramGraph& graph) : RoodNodeDataFlowAnalysis(graph, 10) {}
 
   RoodNodeDataFlowAnalysis(const ProgramGraph& graph, int maxInstancesPerGraph)
       : DataFlowPass(graph),
@@ -87,8 +84,7 @@ class RoodNodeDataFlowAnalysis : public DataFlowPass {
   // GetVariableNodeIndices() to implement this.
   virtual std::vector<int> GetEligibleRootNodes() = 0;
 
-  [[nodiscard]] virtual labm8::Status Run(
-      ProgramGraphFeaturesList* featuresList) override;
+  [[nodiscard]] virtual labm8::Status Run(ProgramGraphFeaturesList* featuresList) override;
 
   [[nodiscard]] virtual labm8::Status Init();
 
@@ -98,8 +94,7 @@ class RoodNodeDataFlowAnalysis : public DataFlowPass {
   void seed(unsigned seed) { seed_ = seed; }
 
  protected:
-  virtual labm8::Status RunOne(int rootNode,
-                               ProgramGraphFeatures* features) = 0;
+  virtual labm8::Status RunOne(int rootNode, ProgramGraphFeatures* features) = 0;
 
  private:
   const int maxInstancesPerGraph_;
@@ -107,11 +102,9 @@ class RoodNodeDataFlowAnalysis : public DataFlowPass {
 };
 
 // Utility function to add a new node feature a list of node features.
-void AddNodeFeature(ProgramGraphFeatures* features, const string& name,
-                    const Feature& value);
+void AddNodeFeature(ProgramGraphFeatures* features, const string& name, const Feature& value);
 
-std::vector<int> GetInstructionsInFunctionsNodeIndices(
-    const ProgramGraph& graph);
+std::vector<int> GetInstructionsInFunctionsNodeIndices(const ProgramGraph& graph);
 
 std::vector<int> GetVariableNodeIndices(const ProgramGraph& graph);
 

--- a/programl/graph/analysis/datadep.cc
+++ b/programl/graph/analysis/datadep.cc
@@ -16,13 +16,13 @@
 
 #include "programl/graph/analysis/datadep.h"
 
-#include "labm8/cpp/logging.h"
-#include "labm8/cpp/status.h"
-#include "programl/graph/features.h"
-
 #include <queue>
 #include <utility>
 #include <vector>
+
+#include "labm8/cpp/logging.h"
+#include "labm8/cpp/status.h"
+#include "programl/graph/features.h"
 
 using labm8::Status;
 using std::vector;
@@ -33,24 +33,19 @@ namespace graph {
 namespace analysis {
 
 Status DatadepAnalysis::Init() {
-  ComputeAdjacencies({.control = false,
-                      .reverse_control = false,
-                      .data = false,
-                      .reverse_data = true});
+  ComputeAdjacencies(
+      {.control = false, .reverse_control = false, .data = false, .reverse_data = true});
   return Status::OK;
 }
 
-vector<int> DatadepAnalysis::GetEligibleRootNodes() {
-  return GetVariableNodeIndices(graph());
-}
+vector<int> DatadepAnalysis::GetEligibleRootNodes() { return GetVariableNodeIndices(graph()); }
 
 Status DatadepAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
   vector<bool> visited(graph().node_size(), false);
 
   const vector<vector<int>>& rdfg = adjacencies().reverse_data;
-  DCHECK(rdfg.size() == graph().node_size())
-      << "RDFG size: " << rdfg.size() << " != "
-      << " graph size: " << graph().node_size();
+  DCHECK(rdfg.size() == graph().node_size()) << "RDFG size: " << rdfg.size() << " != "
+                                             << " graph size: " << graph().node_size();
 
   int dataFlowStepCount = 1;
   std::queue<std::pair<int, int>> q;
@@ -76,8 +71,7 @@ Status DatadepAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
 
   int activeNodeCount = 0;
   for (int i = 0; i < graph().node_size(); ++i) {
-    AddNodeFeature(features, "data_flow_root_node",
-                   i == rootNode ? trueFeature : falseFeature);
+    AddNodeFeature(features, "data_flow_root_node", i == rootNode ? trueFeature : falseFeature);
     if (visited[i] && graph().node(i).type() == Node::INSTRUCTION) {
       ++activeNodeCount;
       AddNodeFeature(features, "data_flow_value", trueFeature);

--- a/programl/graph/analysis/datadep.h
+++ b/programl/graph/analysis/datadep.h
@@ -32,8 +32,7 @@ class DatadepAnalysis : public RoodNodeDataFlowAnalysis {
  public:
   using RoodNodeDataFlowAnalysis::RoodNodeDataFlowAnalysis;
 
-  virtual labm8::Status RunOne(int rootNode,
-                               ProgramGraphFeatures* features) override;
+  virtual labm8::Status RunOne(int rootNode, ProgramGraphFeatures* features) override;
 
   virtual std::vector<int> GetEligibleRootNodes() override;
 

--- a/programl/graph/analysis/dominance.cc
+++ b/programl/graph/analysis/dominance.cc
@@ -121,12 +121,10 @@ Status DominanceAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
 
   int activeNodeCount = 0;
   for (int i = 0; i < graph().node_size(); ++i) {
-    AddNodeFeature(features, "data_flow_root_node",
-                   i == rootNode ? trueFeature : falseFeature);
+    AddNodeFeature(features, "data_flow_root_node", i == rootNode ? trueFeature : falseFeature);
 
     auto it = dominators.find(i);
-    if (it != dominators.end() &&
-        it->second.find(rootNode) != it->second.end()) {
+    if (it != dominators.end() && it->second.find(rootNode) != it->second.end()) {
       ++activeNodeCount;
       AddNodeFeature(features, "data_flow_value", trueFeature);
     } else {
@@ -134,8 +132,7 @@ Status DominanceAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
     }
   }
 
-  SetFeature(features->mutable_features(), "data_flow_step_count",
-             CreateFeature(stepCount));
+  SetFeature(features->mutable_features(), "data_flow_step_count", CreateFeature(stepCount));
   SetFeature(features->mutable_features(), "data_flow_active_node_count",
              CreateFeature(activeNodeCount));
 

--- a/programl/graph/analysis/dominance.h
+++ b/programl/graph/analysis/dominance.h
@@ -15,15 +15,14 @@
 // limitations under the License.
 #pragma once
 
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "labm8/cpp/status.h"
 #include "programl/graph/analysis/data_flow_pass.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_features.pb.h"
-
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-
-#include <utility>
 
 namespace programl {
 namespace graph {
@@ -38,17 +37,15 @@ class DominanceAnalysis : public RoodNodeDataFlowAnalysis {
  public:
   using RoodNodeDataFlowAnalysis::RoodNodeDataFlowAnalysis;
 
-  virtual labm8::Status RunOne(int rootNode,
-                               ProgramGraphFeatures* features) override;
+  virtual labm8::Status RunOne(int rootNode, ProgramGraphFeatures* features) override;
 
   virtual std::vector<int> GetEligibleRootNodes() override;
 
   virtual labm8::Status Init() override;
 
  protected:
-  labm8::Status ComputeDominators(
-      const int rootNode, int* dataFlowSteps,
-      absl::flat_hash_map<int, absl::flat_hash_set<int>>* dominators);
+  labm8::Status ComputeDominators(const int rootNode, int* dataFlowSteps,
+                                  absl::flat_hash_map<int, absl::flat_hash_set<int>>* dominators);
 };
 
 }  // namespace analysis

--- a/programl/graph/analysis/liveness.cc
+++ b/programl/graph/analysis/liveness.cc
@@ -16,10 +16,10 @@
 
 #include "programl/graph/analysis/liveness.h"
 
+#include <queue>
+
 #include "labm8/cpp/logging.h"
 #include "programl/graph/features.h"
-
-#include <queue>
 
 using absl::flat_hash_set;
 using labm8::Status;
@@ -31,22 +31,16 @@ namespace graph {
 namespace analysis {
 
 Status LivenessAnalysis::Init() {
-  ComputeAdjacencies({.control = true,
-                      .reverse_control = true,
-                      .data = true,
-                      .reverse_data = true});
+  ComputeAdjacencies(
+      {.control = true, .reverse_control = true, .data = true, .reverse_data = true});
   const auto& cfg = adjacencies().control;
-  DCHECK(cfg.size() == graph().node_size())
-      << cfg.size() << " != " << graph().node_size();
+  DCHECK(cfg.size() == graph().node_size()) << cfg.size() << " != " << graph().node_size();
   const auto& rcfg = adjacencies().reverse_control;
-  DCHECK(rcfg.size() == graph().node_size())
-      << rcfg.size() << " != " << graph().node_size();
+  DCHECK(rcfg.size() == graph().node_size()) << rcfg.size() << " != " << graph().node_size();
   const auto& dfg = adjacencies().data;
-  DCHECK(dfg.size() == graph().node_size())
-      << dfg.size() << " != " << graph().node_size();
+  DCHECK(dfg.size() == graph().node_size()) << dfg.size() << " != " << graph().node_size();
   const auto& rdfg = adjacencies().reverse_data;
-  DCHECK(rdfg.size() == graph().node_size())
-      << rdfg.size() << " != " << graph().node_size();
+  DCHECK(rdfg.size() == graph().node_size()) << rdfg.size() << " != " << graph().node_size();
 
   // Pre-compute all live-out sets.
   liveInSets_.reserve(graph().node_size());
@@ -95,8 +89,8 @@ Status LivenessAnalysis::Init() {
     // LiveOut(n) = U {LiveIn(p) for p in succ(n)}
     flat_hash_set<int> newOutSet{};
     for (const auto& successor : successors) {
-      newOutSet.merge(flat_hash_set<int>(liveInSets_[successor].begin(),
-                                         liveInSets_[successor].end()));
+      newOutSet.merge(
+          flat_hash_set<int>(liveInSets_[successor].begin(), liveInSets_[successor].end()));
     }
 
     // LiveIn(n) = Gen(n) U {LiveOut(n) - Kill(n)}
@@ -157,8 +151,7 @@ Status LivenessAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
   const auto& outSet = liveOutSets_[rootNode];
   int dataFlowActiveNodeCount = 0;
   for (int i = 0; i < graph().node_size(); ++i) {
-    AddNodeFeature(features, "data_flow_root_node",
-                   i == rootNode ? trueFeature : falseFeature);
+    AddNodeFeature(features, "data_flow_root_node", i == rootNode ? trueFeature : falseFeature);
     if (outSet.contains(i)) {
       ++dataFlowActiveNodeCount;
       AddNodeFeature(features, "data_flow_value", trueFeature);
@@ -196,8 +189,7 @@ Status LivenessAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
   }
 
   AddScalarFeature(features, "data_flow_step_count", maxDistance);
-  AddScalarFeature(features, "data_flow_active_node_count",
-                   dataFlowActiveNodeCount);
+  AddScalarFeature(features, "data_flow_active_node_count", dataFlowActiveNodeCount);
 
   return Status::OK;
 }

--- a/programl/graph/analysis/liveness.h
+++ b/programl/graph/analysis/liveness.h
@@ -15,15 +15,14 @@
 // limitations under the License.
 #pragma once
 
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "labm8/cpp/status.h"
 #include "programl/graph/analysis/data_flow_pass.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_features.pb.h"
-
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-
-#include <vector>
 
 namespace programl {
 namespace graph {
@@ -43,13 +42,9 @@ class LivenessAnalysis : public RoodNodeDataFlowAnalysis {
 
   labm8::Status Init() override;
 
-  const std::vector<absl::flat_hash_set<int>>& live_in_sets() const {
-    return liveInSets_;
-  }
+  const std::vector<absl::flat_hash_set<int>>& live_in_sets() const { return liveInSets_; }
 
-  const std::vector<absl::flat_hash_set<int>>& live_out_sets() const {
-    return liveOutSets_;
-  }
+  const std::vector<absl::flat_hash_set<int>>& live_out_sets() const { return liveOutSets_; }
 
  private:
   // Live-in and live-out sets that are computed during Init().

--- a/programl/graph/analysis/liveness_test.cc
+++ b/programl/graph/analysis/liveness_test.cc
@@ -48,9 +48,7 @@ class LivenessGraphBuilder {
     CHECK(builder_.AddDataEdge(/*position=*/0, src, dst).ok());
   }
 
-  void AddCallEdge(const Node* src, const Node* dst) {
-    CHECK(builder_.AddCallEdge(src, dst).ok());
-  }
+  void AddCallEdge(const Node* src, const Node* dst) { CHECK(builder_.AddCallEdge(src, dst).ok()); }
 
   const Node* GetRootNode() const { return builder_.GetRootNode(); }
 

--- a/programl/graph/analysis/py/analysis_pybind.cc
+++ b/programl/graph/analysis/py/analysis_pybind.cc
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <sstream>
+
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/string.h"
 #include "programl/graph/analysis/analysis.h"
@@ -33,18 +34,17 @@ namespace analysis {
 PYBIND11_MODULE(analysis_pybind, m) {
   m.doc() = "Python bindings for analysis passes";
 
-  m.def("RunAnalysis",
-        [](const string& analysis, const string& serializedProgramGraph) {
-          ProgramGraph graph;
-          graph.ParseFromString(serializedProgramGraph);
+  m.def("RunAnalysis", [](const string& analysis, const string& serializedProgramGraph) {
+    ProgramGraph graph;
+    graph.ParseFromString(serializedProgramGraph);
 
-          ProgramGraphFeaturesList featuresList;
-          RunAnalysis(analysis, graph, &featuresList).RaiseException();
+    ProgramGraphFeaturesList featuresList;
+    RunAnalysis(analysis, graph, &featuresList).RaiseException();
 
-          std::stringstream str;
-          featuresList.SerializeToOstream(&str);
-          return py::bytes(str.str());
-        });
+    std::stringstream str;
+    featuresList.SerializeToOstream(&str);
+    return py::bytes(str.str());
+  });
 }
 
 }  // namespace analysis

--- a/programl/graph/analysis/reachability.cc
+++ b/programl/graph/analysis/reachability.cc
@@ -16,13 +16,13 @@
 
 #include "programl/graph/analysis/reachability.h"
 
-#include "labm8/cpp/logging.h"
-#include "labm8/cpp/status.h"
-#include "programl/graph/features.h"
-
 #include <queue>
 #include <utility>
 #include <vector>
+
+#include "labm8/cpp/logging.h"
+#include "labm8/cpp/status.h"
+#include "programl/graph/features.h"
 
 using labm8::Status;
 using std::vector;
@@ -41,8 +41,7 @@ vector<int> ReachabilityAnalysis::GetEligibleRootNodes() {
   return GetInstructionsInFunctionsNodeIndices(graph());
 }
 
-Status ReachabilityAnalysis::RunOne(int rootNode,
-                                    ProgramGraphFeatures* features) {
+Status ReachabilityAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
   vector<bool> visited(graph().node_size(), false);
 
   int dataFlowStepCount = 0;
@@ -50,9 +49,8 @@ Status ReachabilityAnalysis::RunOne(int rootNode,
   q.push({rootNode, 1});
 
   const vector<vector<int>>& cfg = adjacencies().control;
-  DCHECK(cfg.size() == graph().node_size())
-      << "CFG size: " << cfg.size() << " != "
-      << " graph size: " << graph().node_size();
+  DCHECK(cfg.size() == graph().node_size()) << "CFG size: " << cfg.size() << " != "
+                                            << " graph size: " << graph().node_size();
 
   int activeNodeCount = 0;
   while (!q.empty()) {
@@ -75,10 +73,8 @@ Status ReachabilityAnalysis::RunOne(int rootNode,
   Feature trueFeature = CreateFeature(1);
 
   for (int i = 0; i < graph().node_size(); ++i) {
-    AddNodeFeature(features, "data_flow_root_node",
-                   i == rootNode ? trueFeature : falseFeature);
-    AddNodeFeature(features, "data_flow_value",
-                   visited[i] ? trueFeature : falseFeature);
+    AddNodeFeature(features, "data_flow_root_node", i == rootNode ? trueFeature : falseFeature);
+    AddNodeFeature(features, "data_flow_value", visited[i] ? trueFeature : falseFeature);
   }
 
   SetFeature(features->mutable_features(), "data_flow_step_count",

--- a/programl/graph/analysis/reachability.h
+++ b/programl/graph/analysis/reachability.h
@@ -32,8 +32,7 @@ class ReachabilityAnalysis : public RoodNodeDataFlowAnalysis {
  public:
   using RoodNodeDataFlowAnalysis::RoodNodeDataFlowAnalysis;
 
-  virtual labm8::Status RunOne(int rootNode,
-                               ProgramGraphFeatures* features) override;
+  virtual labm8::Status RunOne(int rootNode, ProgramGraphFeatures* features) override;
 
   virtual std::vector<int> GetEligibleRootNodes() override;
 

--- a/programl/graph/analysis/subexpressions.cc
+++ b/programl/graph/analysis/subexpressions.cc
@@ -16,13 +16,13 @@
 
 #include "programl/graph/analysis/subexpressions.h"
 
-#include "labm8/cpp/logging.h"
-#include "labm8/cpp/status.h"
-#include "programl/graph/features.h"
-
 #include <sstream>
 #include <utility>
 #include <vector>
+
+#include "labm8/cpp/logging.h"
+#include "labm8/cpp/status.h"
+#include "programl/graph/features.h"
 
 using labm8::Status;
 using std::vector;
@@ -94,14 +94,11 @@ Status SubexpressionsAnalysis::Init() {
         opcodeName == "or" || opcodeName == "and" || opcodeName == "xor") {
       // Commutative statement, order by identifier name.
       std::sort(positionOrderedPairs.begin(), positionOrderedPairs.end(),
-                [](const Operand& a, const Operand& b) {
-                  return a.second < b.second;
-                });
+                [](const Operand& a, const Operand& b) { return a.second < b.second; });
     } else {
       // Non-commutative statement, order by position.
-      std::sort(
-          positionOrderedPairs.begin(), positionOrderedPairs.end(),
-          [](const Operand& a, const Operand& b) { return a.first < b.first; });
+      std::sort(positionOrderedPairs.begin(), positionOrderedPairs.end(),
+                [](const Operand& a, const Operand& b) { return a.first < b.first; });
     }
 
     // Now that we have ordered the list, strip the order key to make a list
@@ -138,22 +135,19 @@ vector<int> SubexpressionsAnalysis::GetEligibleRootNodes() {
   return rootNodes;
 }
 
-Status SubexpressionsAnalysis::RunOne(int rootNode,
-                                      ProgramGraphFeatures* features) {
+Status SubexpressionsAnalysis::RunOne(int rootNode, ProgramGraphFeatures* features) {
   for (const auto& expressionSet : subexpressionSets_) {
     if (expressionSet.contains(rootNode)) {
       Feature falseFeature = CreateFeature(0);
       Feature trueFeature = CreateFeature(1);
 
       for (int i = 0; i < graph().node_size(); ++i) {
-        AddNodeFeature(features, "data_flow_root_node",
-                       i == rootNode ? trueFeature : falseFeature);
+        AddNodeFeature(features, "data_flow_root_node", i == rootNode ? trueFeature : falseFeature);
         AddNodeFeature(features, "data_flow_value",
                        expressionSet.contains(i) ? trueFeature : falseFeature);
       }
 
-      SetFeature(features->mutable_features(), "data_flow_step_count",
-                 CreateFeature(2));
+      SetFeature(features->mutable_features(), "data_flow_step_count", CreateFeature(2));
       SetFeature(features->mutable_features(), "data_flow_active_node_count",
                  CreateFeature(expressionSet.size()));
 
@@ -172,8 +166,7 @@ string SubexpressionsAnalysis::ToString() const {
 
 std::ostream& operator<<(std::ostream& os, const SubexpressionsAnalysis& s) {
   os << "Adjacencies:" << std::endl
-     << s.adjacencies()
-     << "#. expression sets: " << s.subexpression_sets().size() << std::endl;
+     << s.adjacencies() << "#. expression sets: " << s.subexpression_sets().size() << std::endl;
   for (int i = 0; i < s.subexpression_sets().size(); ++i) {
     os << "Expression set " << i << ": {";
     int j = 0;

--- a/programl/graph/analysis/subexpressions.h
+++ b/programl/graph/analysis/subexpressions.h
@@ -15,13 +15,12 @@
 // limitations under the License.
 #pragma once
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "labm8/cpp/status.h"
 #include "programl/graph/analysis/data_flow_pass.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_features.pb.h"
-
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 
 namespace programl {
 namespace graph {
@@ -35,8 +34,7 @@ class SubexpressionsAnalysis : public RoodNodeDataFlowAnalysis {
  public:
   using RoodNodeDataFlowAnalysis::RoodNodeDataFlowAnalysis;
 
-  virtual labm8::Status RunOne(int rootNode,
-                               ProgramGraphFeatures* features) override;
+  virtual labm8::Status RunOne(int rootNode, ProgramGraphFeatures* features) override;
 
   virtual std::vector<int> GetEligibleRootNodes() override;
 
@@ -44,8 +42,7 @@ class SubexpressionsAnalysis : public RoodNodeDataFlowAnalysis {
 
   string ToString() const;
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const SubexpressionsAnalysis& dt);
+  friend std::ostream& operator<<(std::ostream& os, const SubexpressionsAnalysis& dt);
 
   // Return a list of instruction node indices which compute the same
   // subexpression.

--- a/programl/graph/analysis/subexpressions_test.cc
+++ b/programl/graph/analysis/subexpressions_test.cc
@@ -39,9 +39,7 @@ class SubexpressionGraphBuilder {
 
   Node* AddVariable() { return builder_.AddVariable("<var>", fn_); }
 
-  Node* AddInstruction(const string& text) {
-    return builder_.AddInstruction(text, fn_);
-  }
+  Node* AddInstruction(const string& text) { return builder_.AddInstruction(text, fn_); }
 
   void AddControlEdge(const Node* src, const Node* dst) {
     CHECK(builder_.AddControlEdge(0, src, dst).ok());

--- a/programl/graph/features.cc
+++ b/programl/graph/features.cc
@@ -25,7 +25,7 @@ Feature CreateFeature(int64_t value) {
   return feature;
 }
 
-Feature CreateFeature(const std::vector<int64_t> &value) {
+Feature CreateFeature(const std::vector<int64_t>& value) {
   Feature feature;
   for (auto v : value) {
     feature.mutable_int64_list()->add_value(v);
@@ -33,13 +33,13 @@ Feature CreateFeature(const std::vector<int64_t> &value) {
   return feature;
 }
 
-Feature CreateFeature(const std::string &value) {
+Feature CreateFeature(const std::string& value) {
   Feature feature;
   feature.mutable_bytes_list()->add_value(value);
   return feature;
 }
 
-void SetFeature(Features *features, const char *label, const Feature &value) {
+void SetFeature(Features* features, const char* label, const Feature& value) {
   (*features->mutable_feature())[label] = value;
 }
 

--- a/programl/graph/features.h
+++ b/programl/graph/features.h
@@ -19,10 +19,10 @@
 // limitations under the License.
 #pragma once
 
-#include "programl/proto/features.pb.h"
-
 #include <string>
 #include <vector>
+
+#include "programl/proto/features.pb.h"
 
 namespace programl {
 namespace graph {
@@ -41,10 +41,8 @@ void SetFeature(Features* features, const char* label, const Feature& value);
 
 // Convenience function to add a scalar feature value.
 template <typename MessageType, typename FeatureType>
-void AddScalarFeature(MessageType* message, const std::string& key,
-                      const FeatureType& value) {
-  message->mutable_features()->mutable_feature()->insert(
-      {key, CreateFeature(value)});
+void AddScalarFeature(MessageType* message, const std::string& key, const FeatureType& value) {
+  message->mutable_features()->mutable_feature()->insert({key, CreateFeature(value)});
 }
 
 }  // namespace graph

--- a/programl/graph/format/cdfg.cc
+++ b/programl/graph/format/cdfg.cc
@@ -15,12 +15,11 @@
 // limitations under the License.
 #include "programl/graph/format/cdfg.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "programl/graph/features.h"
 #include "programl/proto/edge.pb.h"
 #include "programl/proto/node.pb.h"
 #include "programl/proto/program_graph.pb.h"
-
-#include "absl/container/flat_hash_set.h"
 
 namespace programl {
 namespace graph {
@@ -117,8 +116,7 @@ const std::vector<int>& CDFGBuilder::GetNodeList() const { return nodeList_; }
 
 void CDFGBuilder::Clear() { nodeList_.clear(); }
 
-absl::flat_hash_map<int, int> NodeListToTranslationMap(
-    const std::vector<int>& nodeList) {
+absl::flat_hash_map<int, int> NodeListToTranslationMap(const std::vector<int>& nodeList) {
   absl::flat_hash_map<int, int> map;
   map.reserve(nodeList.size());
   for (size_t i = 0; i < nodeList.size(); ++i) {

--- a/programl/graph/format/cdfg.h
+++ b/programl/graph/format/cdfg.h
@@ -22,11 +22,10 @@
 // limitations under the License.
 #pragma once
 
-#include "programl/proto/program_graph.pb.h"
-
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "programl/proto/program_graph.pb.h"
 
 namespace programl {
 namespace graph {
@@ -65,8 +64,7 @@ class CDFGBuilder {
 
 // Convert a list of node indices into a map from node index to new node index.
 // E.g. [1, 2, 5] returns a map {1: 0, 2: 1, 5: 2}.
-absl::flat_hash_map<int, int> NodeListToTranslationMap(
-    const std::vector<int>& nodeList);
+absl::flat_hash_map<int, int> NodeListToTranslationMap(const std::vector<int>& nodeList);
 
 }  // namespace format
 }  // namespace graph

--- a/programl/graph/format/graph_serializer.cc
+++ b/programl/graph/format/graph_serializer.cc
@@ -15,9 +15,9 @@
 // limitations under the License.
 #include "programl/graph/format/graph_serializer.h"
 
-#include "absl/container/flat_hash_set.h"
-
 #include <deque>
+
+#include "absl/container/flat_hash_set.h"
 
 namespace programl {
 namespace graph {
@@ -27,8 +27,7 @@ namespace format {
 // outgoing call edges as functions to visit.
 static const int ROOT_NODE = 0;
 
-void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
-                                         std::vector<int>* serialized,
+void SerializeInstructionsInProgramGraph(const ProgramGraph& graph, std::vector<int>* serialized,
                                          int maxNodes) {
   // An array of function entries to visit, where each function entry is a node
   // that is the destination of an outgoing call edge from the root node.
@@ -56,15 +55,14 @@ void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
   }
 
   for (const auto& function_entry : function_entries_to_visit) {
-    if (SerializeInstructionsInFunction(function_entry, forward_control_edges,
-                                        serialized, maxNodes)) {
+    if (SerializeInstructionsInFunction(function_entry, forward_control_edges, serialized,
+                                        maxNodes)) {
       return;
     }
   }
 }
 
-void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
-                                         NodeIndexList* serialized,
+void SerializeInstructionsInProgramGraph(const ProgramGraph& graph, NodeIndexList* serialized,
                                          int maxNodes) {
   std::vector<int> vec;
   SerializeInstructionsInProgramGraph(graph, &vec, maxNodes);
@@ -74,8 +72,7 @@ void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
 }
 
 bool SerializeInstructionsInFunction(
-    const int& root,
-    const absl::flat_hash_map<int, std::vector<int>>& forward_control_edges,
+    const int& root, const absl::flat_hash_map<int, std::vector<int>>& forward_control_edges,
     std::vector<int>* serialized, int maxNodes) {
   // A set of visited nodes.
   absl::flat_hash_set<int> visited;

--- a/programl/graph/format/graph_serializer.h
+++ b/programl/graph/format/graph_serializer.h
@@ -15,12 +15,11 @@
 // limitations under the License.
 #pragma once
 
-#include "programl/proto/node.pb.h"
-#include "programl/proto/program_graph.pb.h"
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
-
-#include <vector>
+#include "programl/proto/node.pb.h"
+#include "programl/proto/program_graph.pb.h"
 
 namespace programl {
 namespace graph {
@@ -29,23 +28,20 @@ namespace format {
 // Produce a serialized list of node indices for the instructions in a graph.
 // Order is determined by a depth first traversal of the instructions in each
 // function.
-void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
-                                         std::vector<int>* serialized,
+void SerializeInstructionsInProgramGraph(const ProgramGraph& graph, std::vector<int>* serialized,
                                          int maxNodes);
 
 // Produce a serialized list of node indices for the instructions in a graph.
 // Order is determined by a depth first traversal of the instructions in each
 // function.
-void SerializeInstructionsInProgramGraph(const ProgramGraph& graph,
-                                         NodeIndexList* serialized,
+void SerializeInstructionsInProgramGraph(const ProgramGraph& graph, NodeIndexList* serialized,
                                          int maxNodes);
 
 // Produce a serialized list of node indices for the instructions in a graph.
 // Order is determined by a depth first traversal of the instructions in each
 // function.
 bool SerializeInstructionsInFunction(
-    const int& root,
-    const absl::flat_hash_map<int, std::vector<int>>& forward_control_edges,
+    const int& root, const absl::flat_hash_map<int, std::vector<int>>& forward_control_edges,
     std::vector<int>* serialized, int maxNodes);
 
 }  // namespace format

--- a/programl/graph/format/graph_serializer_test.cc
+++ b/programl/graph/format/graph_serializer_test.cc
@@ -15,11 +15,10 @@
 // limitations under the License.
 #include "programl/graph/format/graph_serializer.h"
 
-#include "programl/proto/program_graph.pb.h"
-
 #include <vector>
 
 #include "labm8/cpp/test.h"
+#include "programl/proto/program_graph.pb.h"
 
 namespace programl {
 namespace graph {

--- a/programl/graph/format/graph_tuple.h
+++ b/programl/graph/format/graph_tuple.h
@@ -40,46 +40,29 @@ class GraphTuple {
   const std::array<std::vector<std::pair<int, int>>, 3>& adjacencies() const {
     return adjacencies_;
   }
-  const std::array<std::vector<int>, 3>& edge_positions() const {
-    return edge_positions_;
-  }
+  const std::array<std::vector<int>, 3>& edge_positions() const { return edge_positions_; }
 
   inline size_t graph_size() const { return graph_size_; }
   inline size_t node_size() const { return node_size_; }
   inline size_t edge_size() {
-    return adjacencies_[0].size() + adjacencies_[1].size() +
-           adjacencies_[2].size();
+    return adjacencies_[0].size() + adjacencies_[1].size() + adjacencies_[2].size();
   }
-  inline size_t control_edge_size() const {
-    return adjacencies_[Edge::CONTROL].size();
-  }
-  inline size_t data_edge_size() const {
-    return adjacencies_[Edge::DATA].size();
-  }
-  inline size_t call_edge_size() const {
-    return adjacencies_[Edge::CALL].size();
-  }
+  inline size_t control_edge_size() const { return adjacencies_[Edge::CONTROL].size(); }
+  inline size_t data_edge_size() const { return adjacencies_[Edge::DATA].size(); }
+  inline size_t call_edge_size() const { return adjacencies_[Edge::CALL].size(); }
   inline const std::vector<size_t>& node_sizes() const { return node_sizes_; }
   inline const std::vector<size_t>& edge_sizes() const { return edge_sizes_; }
 
  protected:
-  std::array<std::vector<std::pair<int, int>>, 3>* mutable_adjacencies() {
-    return &adjacencies_;
-  }
+  std::array<std::vector<std::pair<int, int>>, 3>* mutable_adjacencies() { return &adjacencies_; }
 
-  std::array<std::vector<int>, 3>* mutable_edge_positions() {
-    return &edge_positions_;
-  }
+  std::array<std::vector<int>, 3>* mutable_edge_positions() { return &edge_positions_; }
 
   inline void set_node_size(size_t node_size) { node_size_ = node_size; }
 
-  inline void add_node_size(size_t node_size) {
-    node_sizes_.push_back(node_size);
-  }
+  inline void add_node_size(size_t node_size) { node_sizes_.push_back(node_size); }
 
-  inline void add_edge_size(size_t edge_size) {
-    edge_sizes_.push_back(edge_size);
-  }
+  inline void add_edge_size(size_t edge_size) { edge_sizes_.push_back(edge_size); }
 
  private:
   size_t graph_size_;

--- a/programl/graph/format/graph_tuple_test.cc
+++ b/programl/graph/format/graph_tuple_test.cc
@@ -13,9 +13,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <vector>
-
 #include "programl/graph/format/graph_tuple.h"
+
+#include <vector>
 
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/test.h"

--- a/programl/graph/format/graphviz_converter.cc
+++ b/programl/graph/format/graphviz_converter.cc
@@ -19,13 +19,12 @@
 #include <iomanip>
 #include <sstream>
 
-#include "programl/proto/program_graph.pb.h"
-
 #include "absl/container/flat_hash_map.h"
 #include "boost/graph/graphviz.hpp"
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/status_macros.h"
 #include "labm8/cpp/string.h"
+#include "programl/proto/program_graph.pb.h"
 
 namespace error = labm8::error;
 
@@ -39,18 +38,14 @@ static const int kMaximumLabelLen = 32;
 
 using AttributeMap = absl::flat_hash_map<string, string>;
 
-using VertexProperties =
-    boost::property<boost::vertex_attribute_t, AttributeMap>;
-using EdgeProperties =
-    boost::property<boost::edge_index_t, int,
-                    boost::property<boost::edge_attribute_t, AttributeMap>>;
+using VertexProperties = boost::property<boost::vertex_attribute_t, AttributeMap>;
+using EdgeProperties = boost::property<boost::edge_index_t, int,
+                                       boost::property<boost::edge_attribute_t, AttributeMap>>;
 using GraphProperties = boost::property<
     boost::graph_name_t, string,
-    boost::property<
-        boost::graph_graph_attribute_t, AttributeMap,
-        boost::property<
-            boost::graph_vertex_attribute_t, AttributeMap,
-            boost::property<boost::graph_edge_attribute_t, AttributeMap>>>>;
+    boost::property<boost::graph_graph_attribute_t, AttributeMap,
+                    boost::property<boost::graph_vertex_attribute_t, AttributeMap,
+                                    boost::property<boost::graph_edge_attribute_t, AttributeMap>>>>;
 
 // An adjacency list for program graphs. We store the source Edge message as
 // edge properties.
@@ -66,12 +61,9 @@ namespace {
 
 class GraphVizSerializer {
  public:
-  GraphVizSerializer(const ProgramGraph& graph,
-                     const NodeLabel& nodeLabelFormat,
+  GraphVizSerializer(const ProgramGraph& graph, const NodeLabel& nodeLabelFormat,
                      const string& nodeFeatureName)
-      : graph_(graph),
-        nodeLabelFormat_(nodeLabelFormat),
-        nodeFeatureName_(nodeFeatureName) {}
+      : graph_(graph), nodeLabelFormat_(nodeLabelFormat), nodeFeatureName_(nodeFeatureName) {}
 
  private:
   // Set global graphviz properties.
@@ -80,28 +72,24 @@ class GraphVizSerializer {
     boost::get_property(main, boost::graph_graph_attribute)["margin"] = "0";
     boost::get_property(main, boost::graph_graph_attribute)["nodesep"] = "0.4";
     boost::get_property(main, boost::graph_graph_attribute)["ranksep"] = "0.4";
-    boost::get_property(main, boost::graph_graph_attribute)["fontname"] =
-        "Inconsolata";
+    boost::get_property(main, boost::graph_graph_attribute)["fontname"] = "Inconsolata";
     boost::get_property(main, boost::graph_graph_attribute)["fontsize"] = "20";
 
-    boost::get_property(main, boost::graph_vertex_attribute)["fontname"] =
-        "Inconsolata";
+    boost::get_property(main, boost::graph_vertex_attribute)["fontname"] = "Inconsolata";
     boost::get_property(main, boost::graph_vertex_attribute)["fontsize"] = "20";
     boost::get_property(main, boost::graph_vertex_attribute)["penwidth"] = "2";
     boost::get_property(main, boost::graph_vertex_attribute)["width"] = "1";
     boost::get_property(main, boost::graph_vertex_attribute)["margin"] = "0";
 
-    boost::get_property(main, boost::graph_edge_attribute)["fontname"] =
-        "Inconsolata";
+    boost::get_property(main, boost::graph_edge_attribute)["fontname"] = "Inconsolata";
     boost::get_property(main, boost::graph_edge_attribute)["fontsize"] = "20";
     boost::get_property(main, boost::graph_edge_attribute)["penwidth"] = "3";
     boost::get_property(main, boost::graph_edge_attribute)["arrowsize"] = ".8";
   }
 
-  std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>>
-  MakeFunctionGraphs(boost::subgraph<GraphvizGraph>* main) {
-    std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>>
-        functionGraphs;
+  std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>> MakeFunctionGraphs(
+      boost::subgraph<GraphvizGraph>* main) {
+    std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>> functionGraphs;
     for (int i = 0; i < graph_.function_size(); ++i) {
       const auto& function = graph_.function(i);
 
@@ -111,18 +99,15 @@ class GraphVizSerializer {
       // Set the name of the function.
       string functionName = function.name();
       labm8::TruncateWithEllipsis(functionName, kMaximumLabelLen);
-      boost::get_property(functionGraph,
-                          boost::graph_graph_attribute)["label"] = functionName;
-      boost::get_property(functionGraph,
-                          boost::graph_graph_attribute)["margin"] = "10";
-      boost::get_property(functionGraph,
-                          boost::graph_graph_attribute)["style"] = "dotted";
+      boost::get_property(functionGraph, boost::graph_graph_attribute)["label"] = functionName;
+      boost::get_property(functionGraph, boost::graph_graph_attribute)["margin"] = "10";
+      boost::get_property(functionGraph, boost::graph_graph_attribute)["style"] = "dotted";
 
       // Set the name of the graph. Names must begin with "cluster".
       std::stringstream subgraphName;
       subgraphName << "cluster" << functionName;
-      boost::get_property(functionGraphs[functionGraphs.size() - 1].get(),
-                          boost::graph_name) = subgraphName.str();
+      boost::get_property(functionGraphs[functionGraphs.size() - 1].get(), boost::graph_name) =
+          subgraphName.str();
     }
     return functionGraphs;
   }
@@ -137,9 +122,7 @@ class GraphVizSerializer {
     const Feature& feature = it->second;
 
     // Int array
-    for (int i = 0;
-         i < std::min(feature.int64_list().value_size(), kMaximumLabelLen);
-         ++i) {
+    for (int i = 0; i < std::min(feature.int64_list().value_size(), kMaximumLabelLen); ++i) {
       if (i) {
         os << ", ";
       }
@@ -147,18 +130,14 @@ class GraphVizSerializer {
     }
     // Float array
     os << std::setprecision(4);
-    for (int i = 0;
-         i < std::min(feature.float_list().value_size(), kMaximumLabelLen);
-         ++i) {
+    for (int i = 0; i < std::min(feature.float_list().value_size(), kMaximumLabelLen); ++i) {
       if (i) {
         os << ", ";
       }
       os << feature.float_list().value(i);
     }
     // Bytes array
-    for (int i = 0;
-         i < std::min(feature.bytes_list().value_size(), kMaximumLabelLen);
-         ++i) {
+    for (int i = 0; i < std::min(feature.bytes_list().value_size(), kMaximumLabelLen); ++i) {
       if (i) {
         os << ", ";
       }
@@ -217,8 +196,7 @@ class GraphVizSerializer {
   // Create the vertices.
   void CreateVertices(
       boost::subgraph<GraphvizGraph>* defaultGraph,
-      std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>>*
-          functionGraphs) {
+      std::vector<std::reference_wrapper<boost::subgraph<GraphvizGraph>>>* functionGraphs) {
     for (int i = 0; i < graph_.node_size(); ++i) {
       const Node& node = graph_.node(i);
       // Determine the subgraph to add this node to.
@@ -255,8 +233,7 @@ class GraphVizSerializer {
       // Position labels for control edge are drawn close to the originating
       // instruction. For data edges, they are drawn closer to the consuming
       // instruction.
-      const string label =
-          edge.flow() == Edge::DATA ? "headlabel" : "taillabel";
+      const string label = edge.flow() == Edge::DATA ? "headlabel" : "taillabel";
       attributes[label] = std::to_string(edge.position());
       attributes["labelfontcolor"] = attributes["color"];
     }
@@ -307,8 +284,7 @@ class GraphVizSerializer {
 
 }  // anonymous namespace
 
-labm8::Status SerializeGraphVizToString(const ProgramGraph& graph,
-                                        std::ostream* ostream,
+labm8::Status SerializeGraphVizToString(const ProgramGraph& graph, std::ostream* ostream,
                                         const NodeLabel& nodeLabelFormat,
                                         const string& nodeFeatureName) {
   GraphVizSerializer serializer(graph, nodeLabelFormat, nodeFeatureName);

--- a/programl/graph/format/graphviz_converter.h
+++ b/programl/graph/format/graphviz_converter.h
@@ -35,14 +35,13 @@ enum NodeLabel {
 };
 
 // Get the named node feature or return an error status if not found.
-labm8::StatusOr<Feature> GetNodeFeature(const Node& node,
-                                        const string& feature);
+labm8::StatusOr<Feature> GetNodeFeature(const Node& node, const string& feature);
 
 // Serialize the given program graph to an output stream.
-[[nodiscard]] labm8::Status SerializeGraphVizToString(
-    const ProgramGraph& graph, std::ostream* ostream,
-    const NodeLabel& nodeLabelFormat = kText,
-    const string& nodeFeatureName = "");
+[[nodiscard]] labm8::Status SerializeGraphVizToString(const ProgramGraph& graph,
+                                                      std::ostream* ostream,
+                                                      const NodeLabel& nodeLabelFormat = kText,
+                                                      const string& nodeFeatureName = "");
 
 }  // namespace format
 }  // namespace graph

--- a/programl/graph/format/graphviz_converter_test.cc
+++ b/programl/graph/format/graphviz_converter_test.cc
@@ -13,9 +13,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <iostream>
-
 #include "programl/graph/format/graphviz_converter.h"
+
+#include <iostream>
 
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/test.h"

--- a/programl/graph/format/node_link_graph.cc
+++ b/programl/graph/format/node_link_graph.cc
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "programl/graph/format/node_link_graph.h"
+
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/status_macros.h"

--- a/programl/graph/format/node_link_graph.h
+++ b/programl/graph/format/node_link_graph.h
@@ -18,9 +18,8 @@
 #pragma once
 
 #include "labm8/cpp/status.h"
-#include "programl/proto/program_graph.pb.h"
-
 #include "nlohmann/json.hpp"
+#include "programl/proto/program_graph.pb.h"
 
 namespace programl {
 namespace graph {
@@ -32,18 +31,15 @@ namespace format {
 //
 // See:
 // https://networkx.github.io/documentation/stable/reference/readwrite/json_graph.html
-[[nodiscard]] labm8::Status ProgramGraphToNodeLinkGraph(
-    const ProgramGraph& graph, nlohmann::json* dict);
+[[nodiscard]] labm8::Status ProgramGraphToNodeLinkGraph(const ProgramGraph& graph,
+                                                        nlohmann::json* dict);
 
 namespace detail {
 
 // Helpers for converting from program graph to JSON node link graph.
-[[nodiscard]] labm8::Status CreateGraphDict(const ProgramGraph& graph,
-                                            nlohmann::json* graphDict);
-[[nodiscard]] labm8::Status CreateNodesList(const ProgramGraph& graph,
-                                            nlohmann::json* nodes);
-[[nodiscard]] labm8::Status CreateLinksList(const ProgramGraph& graph,
-                                            nlohmann::json* links);
+[[nodiscard]] labm8::Status CreateGraphDict(const ProgramGraph& graph, nlohmann::json* graphDict);
+[[nodiscard]] labm8::Status CreateNodesList(const ProgramGraph& graph, nlohmann::json* nodes);
+[[nodiscard]] labm8::Status CreateLinksList(const ProgramGraph& graph, nlohmann::json* links);
 [[nodiscard]] labm8::Status CreateFeaturesDict(const Features& features,
                                                nlohmann::json* featuresDict);
 [[nodiscard]] labm8::Status CreateFeatureArray(const Feature& feature,

--- a/programl/graph/format/node_link_graph_test.cc
+++ b/programl/graph/format/node_link_graph_test.cc
@@ -13,14 +13,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <vector>
-
-#include "nlohmann/json.hpp"
 #include "programl/graph/format/node_link_graph.h"
+
+#include <vector>
 
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/string.h"
 #include "labm8/cpp/test.h"
+#include "nlohmann/json.hpp"
 #include "programl/proto/program_graph.pb.h"
 
 using json = nlohmann::json;

--- a/programl/graph/format/py/graph_serializer_pybind.cc
+++ b/programl/graph/format/py/graph_serializer_pybind.cc
@@ -15,9 +15,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "programl/graph/format/graph_serializer.h"
-
 #include "labm8/cpp/string.h"
+#include "programl/graph/format/graph_serializer.h"
 #include "programl/proto/program_graph.pb.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
@@ -31,20 +30,21 @@ namespace format {
 PYBIND11_MODULE(graph_serializer_pybind, m) {
   m.doc() = "Python bindings for serializing program graphs";
 
-  m.def("_SerializeInstructionsInProgramGraph",
-        [&](const string& serializedProto, int maxNodes) {
-          // De-serialize the input graph.
-          ProgramGraph graph;
-          if (!graph.ParseFromString(serializedProto)) {
-            throw std::runtime_error("Failed to parse input proto");
-          }
+  m.def(
+      "_SerializeInstructionsInProgramGraph",
+      [&](const string& serializedProto, int maxNodes) {
+        // De-serialize the input graph.
+        ProgramGraph graph;
+        if (!graph.ParseFromString(serializedProto)) {
+          throw std::runtime_error("Failed to parse input proto");
+        }
 
-          std::vector<int> nodeList;
-          SerializeInstructionsInProgramGraph(graph, &nodeList, maxNodes);
+        std::vector<int> nodeList;
+        SerializeInstructionsInProgramGraph(graph, &nodeList, maxNodes);
 
-          return nodeList;
-        },
-        "Convert a program graph to a serialized list of instruction nodes.");
+        return nodeList;
+      },
+      "Convert a program graph to a serialized list of instruction nodes.");
 }
 
 }  // namespace format

--- a/programl/graph/format/py/graph_tuple_pybind.cc
+++ b/programl/graph/format/py/graph_tuple_pybind.cc
@@ -15,9 +15,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "programl/graph/format/graph_tuple.h"
-
 #include "labm8/cpp/string.h"
+#include "programl/graph/format/graph_tuple.h"
 #include "programl/proto/program_graph.pb.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
@@ -47,8 +46,7 @@ PYBIND11_MODULE(graph_tuple_pybind, m) {
       .def_property_readonly("node_sizes", &GraphTuple::node_size)
       .def_property_readonly("edge_sizes", &GraphTuple::edge_size)
       .def_property_readonly("graph_size", &GraphTuple::graph_size)
-      .def_property_readonly("control_edge_size",
-                             &GraphTuple::control_edge_size)
+      .def_property_readonly("control_edge_size", &GraphTuple::control_edge_size)
       .def_property_readonly("data_edge_size", &GraphTuple::data_edge_size)
       .def_property_readonly("call_edge_size", &GraphTuple::call_edge_size);
 }

--- a/programl/graph/format/py/node_link_graph_pybind.cc
+++ b/programl/graph/format/py/node_link_graph_pybind.cc
@@ -16,7 +16,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <pybind11/pybind11.h>
+
 #include <sstream>
+
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/string.h"
 #include "nlohmann/json.hpp"
@@ -35,26 +37,27 @@ namespace format {
 PYBIND11_MODULE(node_link_graph_pybind, m) {
   m.doc() = "This module converts program graphs to JSON node link graph";
 
-  m.def("ProgramGraphToNodeLinkGraph",
-        [&](const string& serializedProto) {
-          // De-serialize the input graph.
-          ProgramGraph graph;
-          if (!graph.ParseFromString(serializedProto)) {
-            throw std::runtime_error("Failed to parse input proto");
-          }
+  m.def(
+      "ProgramGraphToNodeLinkGraph",
+      [&](const string& serializedProto) {
+        // De-serialize the input graph.
+        ProgramGraph graph;
+        if (!graph.ParseFromString(serializedProto)) {
+          throw std::runtime_error("Failed to parse input proto");
+        }
 
-          // Convert to a node link graph.
-          json dict;
-          Status status = ProgramGraphToNodeLinkGraph(graph, &dict);
-          if (!status.ok()) {
-            throw std::runtime_error(status.ToString());
-          }
+        // Convert to a node link graph.
+        json dict;
+        Status status = ProgramGraphToNodeLinkGraph(graph, &dict);
+        if (!status.ok()) {
+          throw std::runtime_error(status.ToString());
+        }
 
-          // Serialize JSON string.
-          py::object obj = dict;
-          return std::move(obj);
-        },
-        "Convert a program graph to JSON node link graph.");
+        // Serialize JSON string.
+        py::object obj = dict;
+        return std::move(obj);
+      },
+      "Convert a program graph to JSON node link graph.");
 }
 
 }  // namespace format

--- a/programl/graph/program_graph_builder.cc
+++ b/programl/graph/program_graph_builder.cc
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "programl/graph/program_graph_builder.h"
+
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/status_macros.h"
@@ -25,8 +26,7 @@ namespace error = labm8::error;
 namespace programl {
 namespace graph {
 
-ProgramGraphBuilder::ProgramGraphBuilder(const ProgramGraphOptions& options)
-    : options_(options) {
+ProgramGraphBuilder::ProgramGraphBuilder(const ProgramGraphOptions& options) : options_(options) {
   // Create the graph root node.
   AddNode(Node::INSTRUCTION, "[external]");
 }
@@ -40,8 +40,7 @@ Module* ProgramGraphBuilder::AddModule(const string& name) {
   return module;
 }
 
-Function* ProgramGraphBuilder::AddFunction(const string& name,
-                                           const Module* module) {
+Function* ProgramGraphBuilder::AddFunction(const string& name, const Module* module) {
   DCHECK(module) << "nullptr argument";
   int32_t index = GetProgramGraph().function_size();
   Function* function = GetMutableProgramGraph()->add_function();
@@ -53,24 +52,19 @@ Function* ProgramGraphBuilder::AddFunction(const string& name,
   return function;
 }
 
-Node* ProgramGraphBuilder::AddInstruction(const string& text,
-                                          const Function* function) {
+Node* ProgramGraphBuilder::AddInstruction(const string& text, const Function* function) {
   DCHECK(function) << "nullptr argument";
   return AddNode(Node::INSTRUCTION, text, function);
 }
 
-Node* ProgramGraphBuilder::AddVariable(const string& text,
-                                       const Function* function) {
+Node* ProgramGraphBuilder::AddVariable(const string& text, const Function* function) {
   DCHECK(function) << "nullptr argument";
   return AddNode(Node::VARIABLE, text, function);
 }
 
-Node* ProgramGraphBuilder::AddConstant(const string& text) {
-  return AddNode(Node::CONSTANT, text);
-}
+Node* ProgramGraphBuilder::AddConstant(const string& text) { return AddNode(Node::CONSTANT, text); }
 
-labm8::StatusOr<Edge*> ProgramGraphBuilder::AddControlEdge(int32_t position,
-                                                           const Node* source,
+labm8::StatusOr<Edge*> ProgramGraphBuilder::AddControlEdge(int32_t position, const Node* source,
                                                            const Node* target) {
   DCHECK(source) << "nullptr argument";
   DCHECK(target) << "nullptr argument";
@@ -87,10 +81,8 @@ labm8::StatusOr<Edge*> ProgramGraphBuilder::AddControlEdge(int32_t position,
   }
   int32_t sourceIndex = GetIndex(source);
   if (sourceIndex && source->function() != target->function()) {
-    const string& sourceFunction =
-        GetProgramGraph().function(source->function()).name();
-    const string& targetFunction =
-        GetProgramGraph().function(target->function()).name();
+    const string& sourceFunction = GetProgramGraph().function(source->function()).name();
+    const string& targetFunction = GetProgramGraph().function(target->function()).name();
     return Status(labm8::error::Code::INVALID_ARGUMENT,
                   "Source and target instructions must belong to the same "
                   "function. Source instruction has function `{}`, "
@@ -101,33 +93,27 @@ labm8::StatusOr<Edge*> ProgramGraphBuilder::AddControlEdge(int32_t position,
   return AddEdge(Edge::CONTROL, position, source, target);
 }
 
-labm8::StatusOr<Edge*> ProgramGraphBuilder::AddDataEdge(int32_t position,
-                                                        const Node* source,
+labm8::StatusOr<Edge*> ProgramGraphBuilder::AddDataEdge(int32_t position, const Node* source,
                                                         const Node* target) {
   DCHECK(source) << "nullptr argument";
   DCHECK(target) << "nullptr argument";
 
-  bool sourceIsData =
-      (source->type() == Node::VARIABLE || source->type() == Node::CONSTANT);
-  bool targetIsData =
-      (target->type() == Node::VARIABLE || target->type() == Node::CONSTANT);
+  bool sourceIsData = (source->type() == Node::VARIABLE || source->type() == Node::CONSTANT);
+  bool targetIsData = (target->type() == Node::VARIABLE || target->type() == Node::CONSTANT);
 
-  if (!((sourceIsData && targetIsData) ||
-        (sourceIsData && target->type() == Node::INSTRUCTION) ||
+  if (!((sourceIsData && targetIsData) || (sourceIsData && target->type() == Node::INSTRUCTION) ||
         (targetIsData && source->type() == Node::INSTRUCTION))) {
     return Status(labm8::error::Code::INVALID_ARGUMENT,
                   "Data edge must connect either an instruction with data "
                   "OR data with an instruction. "
                   "Source has type {} and target has type {}",
-                  Node::Type_Name(source->type()),
-                  Node::Type_Name(target->type()));
+                  Node::Type_Name(source->type()), Node::Type_Name(target->type()));
   }
 
   return AddEdge(Edge::DATA, position, source, target);
 }
 
-labm8::StatusOr<Edge*> ProgramGraphBuilder::AddCallEdge(const Node* source,
-                                                        const Node* target) {
+labm8::StatusOr<Edge*> ProgramGraphBuilder::AddCallEdge(const Node* source, const Node* target) {
   DCHECK(source) << "nullptr argument";
   DCHECK(target) << "nullptr argument";
 
@@ -156,18 +142,17 @@ labm8::Status ProgramGraphBuilder::ValidateGraph() const {
   // Check that all nodes except the root are connected. The root is allowed to
   // have no connections in the case where it is an empty graph.
   if (!emptyModules_.empty()) {
-    return Status(labm8::error::Code::FAILED_PRECONDITION,
-                  "Module `{}` is empty", (*emptyModules_.begin())->name());
+    return Status(labm8::error::Code::FAILED_PRECONDITION, "Module `{}` is empty",
+                  (*emptyModules_.begin())->name());
   }
 
   if (!emptyFunctions_.empty()) {
-    return Status(labm8::error::Code::FAILED_PRECONDITION,
-                  "Function `{}` is empty", (*emptyFunctions_.begin())->name());
+    return Status(labm8::error::Code::FAILED_PRECONDITION, "Function `{}` is empty",
+                  (*emptyFunctions_.begin())->name());
   }
 
   if (!unconnectedNodes_.empty()) {
-    return Status(labm8::error::Code::FAILED_PRECONDITION,
-                  "{} has no connections: `{}`",
+    return Status(labm8::error::Code::FAILED_PRECONDITION, "{} has no connections: `{}`",
                   Node::Type_Name((*unconnectedNodes_.begin())->type()),
                   (*unconnectedNodes_.begin())->text());
   }
@@ -214,8 +199,8 @@ Node* ProgramGraphBuilder::AddNode(const Node::Type& type, const string& text,
   return node;
 }
 
-Edge* ProgramGraphBuilder::AddEdge(const Edge::Flow& flow, int32_t position,
-                                   const Node* source, const Node* target) {
+Edge* ProgramGraphBuilder::AddEdge(const Edge::Flow& flow, int32_t position, const Node* source,
+                                   const Node* target) {
   DCHECK(source) << "nullptr argument";
   DCHECK(target) << "nullptr argument";
 
@@ -237,8 +222,7 @@ Edge* ProgramGraphBuilder::AddEdge(const Edge::Flow& flow, int32_t position,
 namespace {
 
 template <typename T>
-int32_t GetIndexOrDie(const absl::flat_hash_map<T*, int32_t>& map,
-                      const T* element) {
+int32_t GetIndexOrDie(const absl::flat_hash_map<T*, int32_t>& map, const T* element) {
   DCHECK(element) << "nullptr argument";
 
   auto it = map.find(element);

--- a/programl/graph/program_graph_builder.h
+++ b/programl/graph/program_graph_builder.h
@@ -65,16 +65,13 @@ class ProgramGraphBuilder {
   Node* AddConstant(const string& text);
 
   // Edge factories.
-  [[nodiscard]] labm8::StatusOr<Edge*> AddControlEdge(int32_t position,
-                                                      const Node* source,
+  [[nodiscard]] labm8::StatusOr<Edge*> AddControlEdge(int32_t position, const Node* source,
                                                       const Node* target);
 
-  [[nodiscard]] labm8::StatusOr<Edge*> AddDataEdge(int32_t position,
-                                                   const Node* source,
+  [[nodiscard]] labm8::StatusOr<Edge*> AddDataEdge(int32_t position, const Node* source,
                                                    const Node* target);
 
-  [[nodiscard]] labm8::StatusOr<Edge*> AddCallEdge(const Node* source,
-                                                   const Node* target);
+  [[nodiscard]] labm8::StatusOr<Edge*> AddCallEdge(const Node* source, const Node* target);
 
   const Node* GetRootNode() const { return &graph_.node(0); }
 
@@ -99,13 +96,12 @@ class ProgramGraphBuilder {
 
   inline Node* AddNode(const Node::Type& type, const string& text);
 
-  inline Node* AddNode(const Node::Type& type, const string& text,
-                       const Function* function);
+  inline Node* AddNode(const Node::Type& type, const string& text, const Function* function);
 
   // Construct edges.
 
-  inline Edge* AddEdge(const Edge::Flow& flow, int32_t position,
-                       const Node* source, const Node* target);
+  inline Edge* AddEdge(const Edge::Flow& flow, int32_t position, const Node* source,
+                       const Node* target);
 
   // Return a mutable pointer to the graph protocol buffer.
   ProgramGraph* GetMutableProgramGraph() { return &graph_; }

--- a/programl/graph/py/program_graph_builder_pybind.cc
+++ b/programl/graph/py/program_graph_builder_pybind.cc
@@ -17,6 +17,7 @@
 // limitations under the License.
 #include <sstream>
 #include <string>
+
 #include "programl/graph/program_graph_builder.h"
 #include "programl/proto/program_graph_options.pb.h"
 #include "pybind11/pybind11.h"
@@ -34,10 +35,12 @@ ProgramGraphOptions DeserializeOptions(const std::string& serializedOptions) {
   return options;
 }
 
-// A ProgramGraphBuilder class wrapper which adds a constructor for serialized options protos.
+// A ProgramGraphBuilder class wrapper which adds a constructor for serialized
+// options protos.
 class PyProgramGraphBuilder : public ProgramGraphBuilder {
  public:
-  explicit PyProgramGraphBuilder(const std::string& serializedOptions) : ProgramGraphBuilder(DeserializeOptions(serializedOptions)) {}
+  explicit PyProgramGraphBuilder(const std::string& serializedOptions)
+      : ProgramGraphBuilder(DeserializeOptions(serializedOptions)) {}
 };
 
 PYBIND11_MODULE(program_graph_builder_pybind, m) {
@@ -53,79 +56,78 @@ PYBIND11_MODULE(program_graph_builder_pybind, m) {
              return py::bytes(str.str());
            })
       .def("Clear", &PyProgramGraphBuilder::Clear)
-      .def("AddModule",
-           [&](PyProgramGraphBuilder& builder, const string& name) {
-             int index = builder.GetProgramGraph().module_size();
-             builder.AddModule(name);
-             return index;
-           },
-           py::arg("name"))
-      .def("AddFunction",
-           [&](PyProgramGraphBuilder& builder, const string& name, int module) {
-             const Module* mod = &builder.GetProgramGraph().module(module);
-             int index = builder.GetProgramGraph().function_size();
-             builder.AddFunction(name, mod);
-             return index;
-           },
-           py::arg("name"), py::arg("module"))
-      .def("AddInstruction",
-           [&](PyProgramGraphBuilder& builder, const string& text, int function) {
-             const Function* fn = &builder.GetProgramGraph().function(function);
-             int index = builder.GetProgramGraph().node_size();
-             builder.AddInstruction(text, fn);
-             return index;
-           },
-           py::arg("text"), py::arg("function"))
-      .def("AddVariable",
-           [&](PyProgramGraphBuilder& builder, const string& text, int function) {
-             const Function* fn = &builder.GetProgramGraph().function(function);
-             int index = builder.GetProgramGraph().node_size();
-             builder.AddVariable(text, fn);
-             return index;
-           },
-           py::arg("text"), py::arg("function"))
-      .def("AddConstant",
-           [&](PyProgramGraphBuilder& builder, const string& text) {
-             int index = builder.GetProgramGraph().node_size();
-             builder.AddConstant(text);
-             return index;
-           },
-           py::arg("text"))
+      .def(
+          "AddModule",
+          [&](PyProgramGraphBuilder& builder, const string& name) {
+            int index = builder.GetProgramGraph().module_size();
+            builder.AddModule(name);
+            return index;
+          },
+          py::arg("name"))
+      .def(
+          "AddFunction",
+          [&](PyProgramGraphBuilder& builder, const string& name, int module) {
+            const Module* mod = &builder.GetProgramGraph().module(module);
+            int index = builder.GetProgramGraph().function_size();
+            builder.AddFunction(name, mod);
+            return index;
+          },
+          py::arg("name"), py::arg("module"))
+      .def(
+          "AddInstruction",
+          [&](PyProgramGraphBuilder& builder, const string& text, int function) {
+            const Function* fn = &builder.GetProgramGraph().function(function);
+            int index = builder.GetProgramGraph().node_size();
+            builder.AddInstruction(text, fn);
+            return index;
+          },
+          py::arg("text"), py::arg("function"))
+      .def(
+          "AddVariable",
+          [&](PyProgramGraphBuilder& builder, const string& text, int function) {
+            const Function* fn = &builder.GetProgramGraph().function(function);
+            int index = builder.GetProgramGraph().node_size();
+            builder.AddVariable(text, fn);
+            return index;
+          },
+          py::arg("text"), py::arg("function"))
+      .def(
+          "AddConstant",
+          [&](PyProgramGraphBuilder& builder, const string& text) {
+            int index = builder.GetProgramGraph().node_size();
+            builder.AddConstant(text);
+            return index;
+          },
+          py::arg("text"))
 
-      .def("AddControlEdge",
-           [&](PyProgramGraphBuilder& builder, int source, int target,
-               int position) {
-             const Node* sourceNode = &builder.GetProgramGraph().node(source);
-             const Node* targetNode = &builder.GetProgramGraph().node(target);
-             builder.AddControlEdge(position, sourceNode, targetNode)
-                 .status()
-                 .RaiseException();
-           },
-           py::arg("source"), py::arg("target"), py::arg("position"))
+      .def(
+          "AddControlEdge",
+          [&](PyProgramGraphBuilder& builder, int source, int target, int position) {
+            const Node* sourceNode = &builder.GetProgramGraph().node(source);
+            const Node* targetNode = &builder.GetProgramGraph().node(target);
+            builder.AddControlEdge(position, sourceNode, targetNode).status().RaiseException();
+          },
+          py::arg("source"), py::arg("target"), py::arg("position"))
 
-      .def("AddDataEdge",
-           [&](PyProgramGraphBuilder& builder, int source, int target,
-               int position) {
-             const Node* sourceNode = &builder.GetProgramGraph().node(source);
-             const Node* targetNode = &builder.GetProgramGraph().node(target);
-             builder.AddDataEdge(position, sourceNode, targetNode)
-                 .status()
-                 .RaiseException();
-           },
-           py::arg("source"), py::arg("target"), py::arg("position"))
+      .def(
+          "AddDataEdge",
+          [&](PyProgramGraphBuilder& builder, int source, int target, int position) {
+            const Node* sourceNode = &builder.GetProgramGraph().node(source);
+            const Node* targetNode = &builder.GetProgramGraph().node(target);
+            builder.AddDataEdge(position, sourceNode, targetNode).status().RaiseException();
+          },
+          py::arg("source"), py::arg("target"), py::arg("position"))
 
-      .def("AddCallEdge",
-           [&](PyProgramGraphBuilder& builder, int source, int target) {
-             const Node* sourceNode = &builder.GetProgramGraph().node(source);
-             const Node* targetNode = &builder.GetProgramGraph().node(target);
-             builder.AddCallEdge(sourceNode, targetNode)
-                 .status()
-                 .RaiseException();
-           },
-           py::arg("source"), py::arg("target"))
+      .def(
+          "AddCallEdge",
+          [&](PyProgramGraphBuilder& builder, int source, int target) {
+            const Node* sourceNode = &builder.GetProgramGraph().node(source);
+            const Node* targetNode = &builder.GetProgramGraph().node(target);
+            builder.AddCallEdge(sourceNode, targetNode).status().RaiseException();
+          },
+          py::arg("source"), py::arg("target"))
 
-      .def_property_readonly("root",
-                             [&](PyProgramGraphBuilder& builder) { return 0; });
+      .def_property_readonly("root", [&](PyProgramGraphBuilder& builder) { return 0; });
 }
 
 }  // namespace graph

--- a/programl/ir/llvm/clang.cc
+++ b/programl/ir/llvm/clang.cc
@@ -30,14 +30,12 @@ namespace llvm {
 #ifdef __APPLE__
 const char* kClangPath = "clang-llvm-10.0.0-x86_64-apple-darwin/bin/clang++";
 #else
-const char* kClangPath =
-    "clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang++";
+const char* kClangPath = "clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang++";
 #endif
 
 Status Clang::Compile(const string& src, IrList* irs) const {
   for (size_t i = 0; i < compileCommands_.size(); ++i) {
-    auto process = subprocess::Popen(compileCommands_[i],
-                                     subprocess::input{subprocess::PIPE},
+    auto process = subprocess::Popen(compileCommands_[i], subprocess::input{subprocess::PIPE},
                                      subprocess::output{subprocess::PIPE},
                                      subprocess::error{subprocess::PIPE});
     auto stdout = process.communicate(src.c_str(), src.size()).first;
@@ -55,8 +53,8 @@ Status Clang::Compile(const string& src, IrList* irs) const {
   return Status::OK;
 }
 
-std::vector<string> Clang::BuildCompileCommands(const string& baseFlags,
-                                                int timeout, bool abspath) {
+std::vector<string> Clang::BuildCompileCommands(const string& baseFlags, int timeout,
+                                                bool abspath) {
   const string clangPath =
       (abspath ? absl::StrFormat("timeout -s9 %d %s", timeout,
                                  labm8::BazelDataPathOrDie(kClangPath).string())
@@ -76,8 +74,8 @@ std::vector<string> Clang::BuildCompileCommands(const string& baseFlags,
   std::vector<string> commands;
   commands.reserve(opts.size());
   for (const string& opt : opts) {
-    commands.push_back(clangPath + " -emit-llvm -c -S " + baseFlags + " " +
-                       opt + " - -o - -Wno-everything");
+    commands.push_back(clangPath + " -emit-llvm -c -S " + baseFlags + " " + opt +
+                       " - -o - -Wno-everything");
   }
   return commands;
 }

--- a/programl/ir/llvm/clang.h
+++ b/programl/ir/llvm/clang.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <vector>
+
 #include "labm8/cpp/status.h"
 #include "labm8/cpp/string.h"
 #include "programl/proto/ir.pb.h"
@@ -41,8 +42,7 @@ namespace llvm {
 class Clang {
  public:
   Clang(const string& baseFlags, int timeout = 60)
-      : compileCommands_(
-            BuildCompileCommands(baseFlags, timeout, /*abspath=*/true)),
+      : compileCommands_(BuildCompileCommands(baseFlags, timeout, /*abspath=*/true)),
         compileCommandsWithoutAbspath_(
             BuildCompileCommands(baseFlags, timeout, /*abspath=*/false)) {}
 
@@ -53,8 +53,8 @@ class Clang {
   labm8::Status Compile(const string& src, IrList* irs) const;
 
  private:
-  static std::vector<string> BuildCompileCommands(const string& baseFlags,
-                                                  int timeout, bool abspath);
+  static std::vector<string> BuildCompileCommands(const string& baseFlags, int timeout,
+                                                  bool abspath);
 
   const std::vector<string> compileCommands_;
   const std::vector<string> compileCommandsWithoutAbspath_;

--- a/programl/ir/llvm/internal/program_graph_builder.h
+++ b/programl/ir/llvm/internal/program_graph_builder.h
@@ -65,32 +65,26 @@ using ArgumentConsumerMap =
 class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
  public:
   explicit ProgramGraphBuilder(const ProgramGraphOptions& options)
-      : programl::graph::ProgramGraphBuilder(options),
-        blockCount_(0){}
+      : programl::graph::ProgramGraphBuilder(options), blockCount_(0) {}
 
-            [[nodiscard]] labm8::StatusOr<ProgramGraph> Build(
-                const ::llvm::Module& module);
+  [[nodiscard]] labm8::StatusOr<ProgramGraph> Build(const ::llvm::Module& module);
 
   void Clear();
 
  protected:
-  [[nodiscard]] labm8::StatusOr<FunctionEntryExits> VisitFunction(
-      const ::llvm::Function& function, const Function* functionMessage);
+  [[nodiscard]] labm8::StatusOr<FunctionEntryExits> VisitFunction(const ::llvm::Function& function,
+                                                                  const Function* functionMessage);
 
   [[nodiscard]] labm8::StatusOr<BasicBlockEntryExit> VisitBasicBlock(
       const ::llvm::BasicBlock& block, const Function* functionMessage,
       InstructionMap* instructionMap, ArgumentConsumerMap* argumentConsumers,
       std::vector<DataEdge>* dataEdgesToAdd);
 
-  [[nodiscard]] labm8::Status AddCallSite(const Node* source,
-                                          const FunctionEntryExits& target);
+  [[nodiscard]] labm8::Status AddCallSite(const Node* source, const FunctionEntryExits& target);
 
-  Node* AddLlvmInstruction(const ::llvm::Instruction* instruction,
-                           const Function* function);
-  Node* AddLlvmVariable(const ::llvm::Instruction* operand,
-                        const Function* function);
-  Node* AddLlvmVariable(const ::llvm::Argument* argument,
-                        const Function* function);
+  Node* AddLlvmInstruction(const ::llvm::Instruction* instruction, const Function* function);
+  Node* AddLlvmVariable(const ::llvm::Instruction* operand, const Function* function);
+  Node* AddLlvmVariable(const ::llvm::Argument* argument, const Function* function);
   Node* AddLlvmConstant(const ::llvm::Constant* constant);
 
  private:
@@ -105,8 +99,7 @@ class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
   // A map from constant values to <node, position> uses. This map is
   // populated by VisitBasicBlock() and consumed once all functions have been
   // visited.
-  absl::flat_hash_map<const ::llvm::Constant*, std::vector<PositionalNode>>
-      constants_;
+  absl::flat_hash_map<const ::llvm::Constant*, std::vector<PositionalNode>> constants_;
 };
 
 }  // namespace internal

--- a/programl/ir/llvm/internal/program_graph_builder_pass.h
+++ b/programl/ir/llvm/internal/program_graph_builder_pass.h
@@ -40,8 +40,7 @@ class ProgramGraphBuilderPass : public ::llvm::ModulePass {
 
   explicit ProgramGraphBuilderPass(const ProgramGraphOptions& options)
       : ModulePass(ID),
-        graph_(labm8::Status(labm8::error::Code::FAILED_PRECONDITION,
-                             "runOnModule() not called")),
+        graph_(labm8::Status(labm8::error::Code::FAILED_PRECONDITION, "runOnModule() not called")),
         graphBuilder_(options) {}
 
   bool runOnModule(::llvm::Module& module) override;

--- a/programl/ir/llvm/internal/text_encoder.cc
+++ b/programl/ir/llvm/internal/text_encoder.cc
@@ -15,12 +15,12 @@
 // limitations under the License.
 #include "programl/ir/llvm/internal/text_encoder.h"
 
+#include <sstream>
+#include <utility>
+
 #include "labm8/cpp/logging.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include <sstream>
-#include <utility>
 
 namespace programl {
 namespace ir {
@@ -32,7 +32,7 @@ namespace {
 // Produce the textual representation of an LLVM object.
 // Generic implementation works for values, instructions, etc.
 template <typename T>
-string PrintToString(const T &value) {
+string PrintToString(const T& value) {
   string str;
   ::llvm::raw_string_ostream rso(str);
   value.print(rso);
@@ -45,8 +45,7 @@ string PrintToString(const T &value) {
 // If the type is not a pointer, the type argument is returned.
 // Argument pointerDepth is incremented for every level of pointer
 // dereferencing.
-const ::llvm::Type *GetDereferencedType(const ::llvm::Type *type,
-                                        int *pointerDepth) {
+const ::llvm::Type* GetDereferencedType(const ::llvm::Type* type, int* pointerDepth) {
   CHECK(type) << "nullptr type at pointer depth " << *pointerDepth;
   if (type->isPointerTy()) {
     *pointerDepth = *pointerDepth + 1;
@@ -60,7 +59,7 @@ const ::llvm::Type *GetDereferencedType(const ::llvm::Type *type,
 // struct or pointer to struct types, respectively. All other types are
 // serialized as normal.
 template <>
-string PrintToString(const ::llvm::Type &value) {
+string PrintToString(const ::llvm::Type& value) {
   string str;
 
   int pointerDepth = 0;
@@ -80,8 +79,8 @@ string PrintToString(const ::llvm::Type &value) {
 }
 
 template <typename T>
-LlvmTextComponents EncodeAndCache(
-    const T *value, absl::flat_hash_map<const T *, LlvmTextComponents> *cache) {
+LlvmTextComponents EncodeAndCache(const T* value,
+                                  absl::flat_hash_map<const T*, LlvmTextComponents>* cache) {
   auto it = cache->find(value);
   if (it != cache->end()) {
     return it->second;
@@ -96,7 +95,7 @@ LlvmTextComponents EncodeAndCache(
 
 }  // anonymous namespace
 
-LlvmTextComponents TextEncoder::Encode(const ::llvm::Instruction *instruction) {
+LlvmTextComponents TextEncoder::Encode(const ::llvm::Instruction* instruction) {
   // Return from cache if available.
   auto it = instruction_cache_.find(instruction);
   if (it != instruction_cache_.end()) {
@@ -128,7 +127,7 @@ LlvmTextComponents TextEncoder::Encode(const ::llvm::Instruction *instruction) {
   return encoded;
 }
 
-LlvmTextComponents TextEncoder::Encode(const ::llvm::Constant *constant) {
+LlvmTextComponents TextEncoder::Encode(const ::llvm::Constant* constant) {
   // Return from cache if available.
   auto it = constant_cache_.find(constant);
   if (it != constant_cache_.end()) {
@@ -144,15 +143,15 @@ LlvmTextComponents TextEncoder::Encode(const ::llvm::Constant *constant) {
   return encoded;
 }
 
-LlvmTextComponents TextEncoder::Encode(const ::llvm::Value *value) {
+LlvmTextComponents TextEncoder::Encode(const ::llvm::Value* value) {
   return EncodeAndCache(value, &value_cache_);
 }
 
-LlvmTextComponents TextEncoder::Encode(const ::llvm::Type *type) {
+LlvmTextComponents TextEncoder::Encode(const ::llvm::Type* type) {
   return EncodeAndCache(type, &type_cache_);
 }
 
-LlvmTextComponents TextEncoder::Encode(const ::llvm::Argument *argument) {
+LlvmTextComponents TextEncoder::Encode(const ::llvm::Argument* argument) {
   // Return from cache if available.
   auto it = arg_cache_.find(argument);
   if (it != arg_cache_.end()) {

--- a/programl/ir/llvm/internal/text_encoder.h
+++ b/programl/ir/llvm/internal/text_encoder.h
@@ -60,13 +60,13 @@ class TextEncoder {
   // concatenating it with the type.
   //
   // See: https://lists.llvm.org/pipermail/llvm-dev/2010-April/030726.html
-  LlvmTextComponents Encode(const ::llvm::Instruction *instruction);
+  LlvmTextComponents Encode(const ::llvm::Instruction* instruction);
   // Fields set: text, lhs, and lhs_type.
-  LlvmTextComponents Encode(const ::llvm::Constant *constant);
+  LlvmTextComponents Encode(const ::llvm::Constant* constant);
   // Fields set: text, lhs, and lhs_type.
-  LlvmTextComponents Encode(const ::llvm::Argument *argument);
-  LlvmTextComponents Encode(const ::llvm::Value *value);
-  LlvmTextComponents Encode(const ::llvm::Type *type);
+  LlvmTextComponents Encode(const ::llvm::Argument* argument);
+  LlvmTextComponents Encode(const ::llvm::Value* value);
+  LlvmTextComponents Encode(const ::llvm::Type* type);
 
   // Clear the encoded string cache.
   void Clear();
@@ -75,13 +75,11 @@ class TextEncoder {
   // Caches to map LLVM IR objects to their encoded representations. We cache
   // objects since serializing and string manipulation can be expensive, and may
   // need to be performed many times for each object, dependning on its usage.
-  absl::flat_hash_map<const ::llvm::Instruction *, LlvmTextComponents>
-      instruction_cache_;
-  absl::flat_hash_map<const ::llvm::Constant *, LlvmTextComponents>
-      constant_cache_;
-  absl::flat_hash_map<const ::llvm::Argument *, LlvmTextComponents> arg_cache_;
-  absl::flat_hash_map<const ::llvm::Value *, LlvmTextComponents> value_cache_;
-  absl::flat_hash_map<const ::llvm::Type *, LlvmTextComponents> type_cache_;
+  absl::flat_hash_map<const ::llvm::Instruction*, LlvmTextComponents> instruction_cache_;
+  absl::flat_hash_map<const ::llvm::Constant*, LlvmTextComponents> constant_cache_;
+  absl::flat_hash_map<const ::llvm::Argument*, LlvmTextComponents> arg_cache_;
+  absl::flat_hash_map<const ::llvm::Value*, LlvmTextComponents> value_cache_;
+  absl::flat_hash_map<const ::llvm::Type*, LlvmTextComponents> type_cache_;
 };
 
 }  // namespace internal

--- a/programl/ir/llvm/llvm.cc
+++ b/programl/ir/llvm/llvm.cc
@@ -38,8 +38,7 @@ Status BuildProgramGraph(::llvm::Module& module, ProgramGraph* graph,
 
   // Create a graph builder pass. Ownership of this pointer is transferred to
   // legacy::PassManager on add().
-  internal::ProgramGraphBuilderPass* pass =
-      new internal::ProgramGraphBuilderPass(options);
+  internal::ProgramGraphBuilderPass* pass = new internal::ProgramGraphBuilderPass(options);
   passManager.add(pass);
 
   passManager.run(module);
@@ -47,8 +46,7 @@ Status BuildProgramGraph(::llvm::Module& module, ProgramGraph* graph,
   return Status::OK;
 }
 
-Status BuildProgramGraph(const ::llvm::MemoryBuffer& irBuffer,
-                         ProgramGraph* graph,
+Status BuildProgramGraph(const ::llvm::MemoryBuffer& irBuffer, ProgramGraph* graph,
                          const ProgramGraphOptions& options) {
   ::llvm::SMDiagnostic error;
   ::llvm::LLVMContext ctx;
@@ -61,11 +59,9 @@ Status BuildProgramGraph(const ::llvm::MemoryBuffer& irBuffer,
     // 1:0: error: expected top-level entity
     //     node {
     //     ^
-    return Status(labm8::error::Code::INVALID_ARGUMENT,
-                  "{}:{}: error: {}\n    {}\n    {}^", error.getLineNo(),
-                  error.getColumnNo(), error.getMessage().str(),
-                  error.getLineContents().str(),
-                  string(std::max(error.getColumnNo() - 1, 0), ' '));
+    return Status(labm8::error::Code::INVALID_ARGUMENT, "{}:{}: error: {}\n    {}\n    {}^",
+                  error.getLineNo(), error.getColumnNo(), error.getMessage().str(),
+                  error.getLineContents().str(), string(std::max(error.getColumnNo() - 1, 0), ' '));
   }
 
   return BuildProgramGraph(*module, graph, options);

--- a/programl/ir/llvm/llvm.h
+++ b/programl/ir/llvm/llvm.h
@@ -32,19 +32,16 @@ namespace llvm {
 const static ProgramGraphOptions defaultOptions;
 
 // Construct a program graph from the given module.
-labm8::Status BuildProgramGraph(
-    ::llvm::Module& module, ProgramGraph* graph,
-    const ProgramGraphOptions& options = defaultOptions);
+labm8::Status BuildProgramGraph(::llvm::Module& module, ProgramGraph* graph,
+                                const ProgramGraphOptions& options = defaultOptions);
 
 // Construct a program graph from a buffer for a module.
-labm8::Status BuildProgramGraph(
-    const ::llvm::MemoryBuffer& irBuffer, ProgramGraph* graph,
-    const ProgramGraphOptions& options = defaultOptions);
+labm8::Status BuildProgramGraph(const ::llvm::MemoryBuffer& irBuffer, ProgramGraph* graph,
+                                const ProgramGraphOptions& options = defaultOptions);
 
 // Construct a program graph from a string of IR.
-labm8::Status BuildProgramGraph(
-    const string& irString, ProgramGraph* graph,
-    const ProgramGraphOptions& options = defaultOptions);
+labm8::Status BuildProgramGraph(const string& irString, ProgramGraph* graph,
+                                const ProgramGraphOptions& options = defaultOptions);
 
 }  // namespace llvm
 }  // namespace ir

--- a/programl/ir/llvm/py/graph_builder_bin.cc
+++ b/programl/ir/llvm/py/graph_builder_bin.cc
@@ -17,11 +17,10 @@
 #include <iostream>
 
 #include "labm8/cpp/status.h"
+#include "llvm/Support/SourceMgr.h"
 #include "programl/ir/llvm/llvm.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_options.pb.h"
-
-#include "llvm/Support/SourceMgr.h"
 
 using labm8::Status;
 
@@ -39,8 +38,7 @@ int main(int argc, char** argv) {
   }
 
   programl::ProgramGraph graph;
-  Status status =
-      programl::ir::llvm::BuildProgramGraph(*buffer.get(), &graph, options);
+  Status status = programl::ir::llvm::BuildProgramGraph(*buffer.get(), &graph, options);
   if (!status.ok()) {
     std::cerr << status.error_message() << std::endl;
     return 2;

--- a/programl/ir/xla/hlo_module_graph_builder.cc
+++ b/programl/ir/xla/hlo_module_graph_builder.cc
@@ -15,35 +15,31 @@
 // limitations under the License.
 #include "programl/ir/xla/hlo_module_graph_builder.h"
 
+#include <sstream>
+
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status_macros.h"
 #include "labm8/cpp/string.h"
 #include "programl/ir/xla/xla_stringifier.h"
-
 #include "tensorflow/compiler/xla/xla_data.pb.h"
-
-#include <sstream>
 
 namespace programl {
 namespace ir {
 namespace xla {
 
-labm8::StatusOr<ProgramGraph> HloModuleGraphBuilder::Build(
-    const ::xla::HloProto& proto) {
+labm8::StatusOr<ProgramGraph> HloModuleGraphBuilder::Build(const ::xla::HloProto& proto) {
   RETURN_IF_ERROR(VisitModule(proto.hlo_module()));
   return GetProgramGraph();
 }
 
-labm8::Status HloModuleGraphBuilder::VisitModule(
-    const ::xla::HloModuleProto& module) {
+labm8::Status HloModuleGraphBuilder::VisitModule(const ::xla::HloModuleProto& module) {
   Module* mod = AddModule(module.name());
 
   // Instantiate the "functions" from HloComputations. Functions are defined in
   // the order of dependencies.
   for (int i = 0; i < module.computations_size(); ++i) {
     FunctionEntryExits computation;
-    ASSIGN_OR_RETURN(computation,
-                     VisitComputation(module.computations(i), mod));
+    ASSIGN_OR_RETURN(computation, VisitComputation(module.computations(i), mod));
     computations_.insert({module.computations(i).id(), computation});
   }
 
@@ -53,8 +49,7 @@ labm8::Status HloModuleGraphBuilder::VisitModule(
     return labm8::Status(labm8::error::Code::INVALID_ARGUMENT,
                          "Failed to locate entry computation");
   }
-  RETURN_IF_ERROR(
-      AddCallEdge(GetRootNode(), entryComputation->second.first).status());
+  RETURN_IF_ERROR(AddCallEdge(GetRootNode(), entryComputation->second.first).status());
   for (const auto& exit : entryComputation->second.second) {
     RETURN_IF_ERROR(AddCallEdge(exit, GetRootNode()).status());
   }
@@ -75,9 +70,8 @@ labm8::StatusOr<FunctionEntryExits> HloModuleGraphBuilder::VisitComputation(
   // producers appear before consumers.
   Node* lastInstruction = entryInstruction;
   for (int i = 0; i < computation.instructions_size(); ++i) {
-    ASSIGN_OR_RETURN(
-        lastInstruction,
-        VisitInstruction(computation.instructions(i), fn, entryInstruction));
+    ASSIGN_OR_RETURN(lastInstruction,
+                     VisitInstruction(computation.instructions(i), fn, entryInstruction));
   }
 
   // Since instructions are in a valid execution order, the last instruction
@@ -86,8 +80,7 @@ labm8::StatusOr<FunctionEntryExits> HloModuleGraphBuilder::VisitComputation(
 }
 
 labm8::StatusOr<Node*> HloModuleGraphBuilder::VisitInstruction(
-    const ::xla::HloInstructionProto& instruction, Function* function,
-    Node* entryInstruction) {
+    const ::xla::HloInstructionProto& instruction, Function* function, Node* entryInstruction) {
   bool isParam = instruction.opcode() == "parameter";
   const string name = isParam ? "<param>" : HloInstructionToText(instruction);
 
@@ -102,15 +95,11 @@ labm8::StatusOr<Node*> HloModuleGraphBuilder::VisitInstruction(
 
   if (instruction.opcode() == "parameter") {
     // Add the implicit control edge from computation entry point to parameters.
-    RETURN_IF_ERROR(
-        AddControlEdge(/*position=*/0, entryInstruction, instructionNode)
-            .status());
+    RETURN_IF_ERROR(AddControlEdge(/*position=*/0, entryInstruction, instructionNode).status());
   } else if (instruction.opcode() == "constant") {
     // Generate the immediate value nodes for constants.
     Node* literal = AddConstant(LiteralProtoToText(instruction.literal()));
-    RETURN_IF_ERROR(
-        AddDataEdge(instruction.operand_ids_size(), literal, instructionNode)
-            .status());
+    RETURN_IF_ERROR(AddDataEdge(instruction.operand_ids_size(), literal, instructionNode).status());
   }
 
   // Add data and control edges from consumer to producer..
@@ -122,17 +111,14 @@ labm8::StatusOr<Node*> HloModuleGraphBuilder::VisitInstruction(
           << instruction.operand_ids(i);
       return labm8::Status(labm8::error::Code::INVALID_ARGUMENT, err.str());
     }
-    RETURN_IF_ERROR(
-        AddDataEdge(/*position=*/i, operandData->second, instructionNode)
-            .status());
+    RETURN_IF_ERROR(AddDataEdge(/*position=*/i, operandData->second, instructionNode).status());
 
     auto pred = instructions_.find(instruction.operand_ids(i));
     if (pred == instructions_.end()) {
       return labm8::Status(labm8::error::Code::INVALID_ARGUMENT,
                            "Failed to find operand instruction");
     }
-    RETURN_IF_ERROR(
-        AddControlEdge(/*position=*/i, pred->second, instructionNode).status());
+    RETURN_IF_ERROR(AddControlEdge(/*position=*/i, pred->second, instructionNode).status());
   }
 
   // Add explicit control dependencies.
@@ -142,8 +128,7 @@ labm8::StatusOr<Node*> HloModuleGraphBuilder::VisitInstruction(
       return labm8::Status(labm8::error::Code::INVALID_ARGUMENT,
                            "Failed to find control predecessor");
     }
-    RETURN_IF_ERROR(
-        AddControlEdge(/*position=*/0, pred->second, instructionNode).status());
+    RETURN_IF_ERROR(AddControlEdge(/*position=*/0, pred->second, instructionNode).status());
   }
 
   // Add call edges from instructions to computations.
@@ -156,8 +141,7 @@ labm8::StatusOr<Node*> HloModuleGraphBuilder::VisitInstruction(
                            "Failed to locate called computation");
     }
     RETURN_IF_ERROR(
-        AddCallEdge(instructionNode, calledComputationEntryExits->second.first)
-            .status());
+        AddCallEdge(instructionNode, calledComputationEntryExits->second.first).status());
     for (const auto& exit : calledComputationEntryExits->second.second) {
       RETURN_IF_ERROR(AddCallEdge(exit, instructionNode).status());
     }

--- a/programl/ir/xla/hlo_module_graph_builder.h
+++ b/programl/ir/xla/hlo_module_graph_builder.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
-
 #include "labm8/cpp/port.h"
 #include "labm8/cpp/statusor.h"
 #include "programl/graph/program_graph_builder.h"
@@ -50,8 +49,7 @@ class HloModuleGraphBuilder : graph::ProgramGraphBuilder {
       const ::xla::HloComputationProto& computation, const Module* module);
 
   [[nodiscard]] labm8::StatusOr<Node*> VisitInstruction(
-      const ::xla::HloInstructionProto& instruction, Function* function,
-      Node* entryInstruction);
+      const ::xla::HloInstructionProto& instruction, Function* function, Node* entryInstruction);
 
  private:
   // A map from computations to their entry and exit nodes.

--- a/programl/ir/xla/hlo_proto_reader.cc
+++ b/programl/ir/xla/hlo_proto_reader.cc
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <sstream>
 #include <streambuf>
+
 #include "labm8/cpp/status_macros.h"
 
 namespace programl {
@@ -28,8 +29,7 @@ labm8::StatusOr<string> ReadFileOrStdin(const string& path, std::istream& ins) {
   string str;
 
   if (path == "-") {
-    str.assign((std::istreambuf_iterator<char>(ins)),
-               std::istreambuf_iterator<char>());
+    str.assign((std::istreambuf_iterator<char>(ins)), std::istreambuf_iterator<char>());
   } else {
     std::ifstream file(path, std::ios::ate);
     if (!file) {
@@ -41,23 +41,20 @@ labm8::StatusOr<string> ReadFileOrStdin(const string& path, std::istream& ins) {
     str.reserve(file.tellg());
     file.seekg(0, std::ios::beg);
 
-    str.assign((std::istreambuf_iterator<char>(file)),
-               std::istreambuf_iterator<char>());
+    str.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   }
 
   return str;
 }
 
-labm8::StatusOr<::xla::HloProto> GetHloProtoFromFileOrStdin(const string& path,
-                                                            bool wireFormat) {
+labm8::StatusOr<::xla::HloProto> GetHloProtoFromFileOrStdin(const string& path, bool wireFormat) {
   string serializedProto;
   ASSIGN_OR_RETURN(serializedProto, ReadFileOrStdin(path));
 
   ::xla::HloProto proto;
   if (wireFormat) {
     if (!proto.ParseFromString(serializedProto)) {
-      return labm8::Status(labm8::error::Code::INVALID_ARGUMENT,
-                           "Failed to parse HloProto\n");
+      return labm8::Status(labm8::error::Code::INVALID_ARGUMENT, "Failed to parse HloProto\n");
     }
   } else {
     // TODO

--- a/programl/ir/xla/hlo_proto_reader.h
+++ b/programl/ir/xla/hlo_proto_reader.h
@@ -17,27 +17,26 @@
 // limitations under the License.
 #pragma once
 
+#include <istream>
+
 #include "labm8/cpp/statusor.h"
 #include "labm8/cpp/string.h"
 #include "tensorflow/compiler/xla/service/hlo.pb.h"
-
-#include <istream>
 
 namespace programl {
 namespace ir {
 namespace xla {
 
 // Read the contents of a file to string.
-labm8::StatusOr<string> ReadFileOrStdin(const string& path,
-                                        std::istream& stdin = std::cin);
+labm8::StatusOr<string> ReadFileOrStdin(const string& path, std::istream& stdin = std::cin);
 
 // Read a HloProto message from a file.
 //
 // Args:
 //     wireFormat: If true, read wire format proto. Else, read text
 //         format proto.
-labm8::StatusOr<::xla::HloProto> GetHloProtoFromFileOrStdin(
-    const string& path, bool wireFormat = true);
+labm8::StatusOr<::xla::HloProto> GetHloProtoFromFileOrStdin(const string& path,
+                                                            bool wireFormat = true);
 
 }  // namespace xla
 }  // namespace ir

--- a/programl/ir/xla/hlo_proto_reader_test.cc
+++ b/programl/ir/xla/hlo_proto_reader_test.cc
@@ -15,9 +15,9 @@
 // limitations under the License.
 #include "programl/ir/xla/hlo_proto_reader.h"
 
-#include "labm8/cpp/test.h"
-
 #include <fstream>
+
+#include "labm8/cpp/test.h"
 
 namespace programl {
 namespace ir {

--- a/programl/ir/xla/py/xla_pybind.cc
+++ b/programl/ir/xla/py/xla_pybind.cc
@@ -16,7 +16,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <pybind11/pybind11.h>
+
 #include <sstream>
+
 #include "labm8/cpp/statusor.h"
 #include "labm8/cpp/string.h"
 #include "programl/ir/xla/hlo_module_graph_builder.h"
@@ -26,19 +28,20 @@ namespace py = pybind11;
 PYBIND11_MODULE(xla_pybind, m) {
   m.doc() = "Generate program graphs from XLA HLO modules.";
 
-  m.def("BuildProgramGraphProto",
-        [&](const string& serializedProto) {
-          programl::ir::xla::HloModuleGraphBuilder builder;
-          ::xla::HloProto proto;
-          if (!proto.ParseFromString(serializedProto)) {
-            throw std::runtime_error("Failed to parse input proto");
-          }
+  m.def(
+      "BuildProgramGraphProto",
+      [&](const string& serializedProto) {
+        programl::ir::xla::HloModuleGraphBuilder builder;
+        ::xla::HloProto proto;
+        if (!proto.ParseFromString(serializedProto)) {
+          throw std::runtime_error("Failed to parse input proto");
+        }
 
-          auto graph = builder.Build(proto).ValueOrException();
+        auto graph = builder.Build(proto).ValueOrException();
 
-          std::stringstream out;
-          graph.SerializeToOstream(&out);
-          return py::bytes(out.str());
-        },
-        "Build a serialized ProgramGraph from a serialized HloProto.");
+        std::stringstream out;
+        graph.SerializeToOstream(&out);
+        return py::bytes(out.str());
+      },
+      "Build a serialized ProgramGraph from a serialized HloProto.");
 }

--- a/programl/ir/xla/xla_stringifier.cc
+++ b/programl/ir/xla/xla_stringifier.cc
@@ -32,8 +32,7 @@ string ShapeProtoToString(const ::xla::ShapeProto& shape) {
 }
 
 string HloInstructionToText(const ::xla::HloInstructionProto& instruction) {
-  if (instruction.opcode() == "parameter" ||
-      instruction.opcode() == "constant") {
+  if (instruction.opcode() == "parameter" || instruction.opcode() == "constant") {
     return instruction.name();
   }
 

--- a/programl/ir/xla/xla_stringifier.h
+++ b/programl/ir/xla/xla_stringifier.h
@@ -25,11 +25,11 @@ namespace programl {
 namespace ir {
 namespace xla {
 
-string ShapeProtoToString(const ::xla::ShapeProto &shape);
+string ShapeProtoToString(const ::xla::ShapeProto& shape);
 
-string HloInstructionToText(const ::xla::HloInstructionProto &instruction);
+string HloInstructionToText(const ::xla::HloInstructionProto& instruction);
 
-string LiteralProtoToText(const ::xla::LiteralProto &literal);
+string LiteralProtoToText(const ::xla::LiteralProto& literal);
 
 }  // namespace xla
 }  // namespace ir

--- a/programl/task/classifyapp/dataset/create.cc
+++ b/programl/task/classifyapp/dataset/create.cc
@@ -42,8 +42,7 @@ DEFINE_string(url,
               "https://drive.google.com/u/0/"
               "uc?id=0B2i-vWnOu7MxVlJwQXN6eVNONUU&export=download",
               "The URL of the author-provided archive.tar.gz file.");
-DEFINE_string(path, "/tmp/programl/poj104",
-              "The directory to write generated files to.");
+DEFINE_string(path, "/tmp/programl/poj104", "The directory to write generated files to.");
 
 int main(int argc, char** argv) {
   labm8::InitApp(&argc, &argv);
@@ -51,7 +50,6 @@ int main(int argc, char** argv) {
     std::cerr << "fatal: Unrecognized arguments" << std::endl;
     return 4;
   }
-  programl::task::classifyapp::CreatePoj104Dataset(FLAGS_url,
-                                                   fs::path(FLAGS_path));
+  programl::task::classifyapp::CreatePoj104Dataset(FLAGS_url, fs::path(FLAGS_path));
   return 0;
 }

--- a/programl/task/classifyapp/dataset/poj104.h
+++ b/programl/task/classifyapp/dataset/poj104.h
@@ -22,8 +22,7 @@ namespace programl {
 namespace task {
 namespace classifyapp {
 
-size_t CreatePoj104Dataset(const string& url,
-                           const boost::filesystem::path& outputPath);
+size_t CreatePoj104Dataset(const string& url, const boost::filesystem::path& outputPath);
 
 }  // namespace classifyapp
 }  // namespace task

--- a/programl/task/dataflow/dataset/parallel_file_map.cc
+++ b/programl/task/dataflow/dataset/parallel_file_map.cc
@@ -24,12 +24,11 @@
 #include <iostream>
 #include <random>
 
+#include "absl/strings/str_format.h"
 #include "boost/filesystem.hpp"
 #include "labm8/cpp/app.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/strutil.h"
-
-#include "absl/strings/str_format.h"
 
 namespace fs = boost::filesystem;
 

--- a/programl/task/dataflow/dataset/unpack_ir_lists.cc
+++ b/programl/task/dataflow/dataset/unpack_ir_lists.cc
@@ -21,40 +21,34 @@
 #include <iomanip>
 #include <iostream>
 
+#include "absl/strings/str_format.h"
 #include "boost/filesystem.hpp"
 #include "labm8/cpp/app.h"
 #include "labm8/cpp/fsutil.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/strutil.h"
-
 #include "programl/proto/ir.pb.h"
 #include "programl/task/dataflow/dataset/parallel_file_map.h"
-
-#include "absl/strings/str_format.h"
 
 namespace fs = boost::filesystem;
 using std::vector;
 
 const char* usage = R"(Unpack IrList protos to Ir protos.)";
 
-DEFINE_string(
-    path,
-    (labm8::fsutil::GetHomeDirectoryOrDie() / "programl/dataflow").string(),
-    "The directory to write generated files to.");
+DEFINE_string(path, (labm8::fsutil::GetHomeDirectoryOrDie() / "programl/dataflow").string(),
+              "The directory to write generated files to.");
 
 namespace programl {
 namespace task {
 namespace dataflow {
 
-inline string GetOutput(const fs::path& root, const string& nameStem,
-                        int index) {
+inline string GetOutput(const fs::path& root, const string& nameStem, int index) {
   return absl::StrFormat("%s/ir/%s%d.Ir.pb", root.string(), nameStem, index);
 }
 
 void ProcessIrList(const fs::path& root, const fs::path& path) {
   const string baseName = path.string().substr(path.string().rfind("/") + 1);
-  const string nameStem =
-      baseName.substr(0, baseName.size() - labm8::StrLen("IrList.pb"));
+  const string nameStem = baseName.substr(0, baseName.size() - labm8::StrLen("IrList.pb"));
 
   std::ifstream file(path.string());
   IrList irList;
@@ -65,8 +59,7 @@ void ProcessIrList(const fs::path& root, const fs::path& path) {
 
   // Write each Ir to its own file.
   for (int i = 0; i < irList.ir_size(); ++i) {
-    const string outPath =
-        absl::StrFormat("%s/ir/%s.%d.Ir.pb", root.string(), nameStem, i);
+    const string outPath = absl::StrFormat("%s/ir/%s.%d.Ir.pb", root.string(), nameStem, i);
     std::ofstream out(outPath);
     irList.ir(i).SerializeToOstream(&out);
   }
@@ -97,11 +90,10 @@ int main(int argc, char** argv) {
   }
 
   const fs::path path(FLAGS_path);
-  const vector<fs::path> files =
-      programl::task::dataflow::EnumerateIrLists(path / "ir");
+  const vector<fs::path> files = programl::task::dataflow::EnumerateIrLists(path / "ir");
 
-  programl::task::dataflow::ParallelFileMap<
-      programl::task::dataflow::ProcessIrList, 128>(path, files);
+  programl::task::dataflow::ParallelFileMap<programl::task::dataflow::ProcessIrList, 128>(path,
+                                                                                          files);
   LOG(INFO) << "done";
 
   return 0;

--- a/programl/test/analysis_test_macros.h
+++ b/programl/test/analysis_test_macros.h
@@ -18,47 +18,30 @@
 #pragma once
 
 // Read a scalar int64 feature value.
-#define SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures, featureName)          \
-  (*(programGraphFeatures).mutable_features()->mutable_feature())[featureName] \
-      .int64_list()                                                            \
-      .value(0)
+#define SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures, featureName) \
+  (*(programGraphFeatures).mutable_features()->mutable_feature())[featureName].int64_list().value(0)
 
 // Read a scalar int64 node feature value.
-#define SCALAR_INT64_NODE_FEATURE(programGraphFeatures, featureName, \
-                                  nodeIndex)                         \
-  (*(programGraphFeatures)                                           \
-        .mutable_node_features()                                     \
-        ->mutable_feature_list())[featureName]                       \
-      .feature(nodeIndex)                                            \
-      .int64_list()                                                  \
+#define SCALAR_INT64_NODE_FEATURE(programGraphFeatures, featureName, nodeIndex)          \
+  (*(programGraphFeatures).mutable_node_features()->mutable_feature_list())[featureName] \
+      .feature(nodeIndex)                                                                \
+      .int64_list()                                                                      \
       .value(0)
 
-#define EXPECT_STEP_COUNT(programGraphFeatures, val)            \
-  EXPECT_EQ(SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures,    \
-                                       "data_flow_step_count"), \
-            (val))
+#define EXPECT_STEP_COUNT(programGraphFeatures, val) \
+  EXPECT_EQ(SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures, "data_flow_step_count"), (val))
 
-#define EXPECT_ACTIVE_NODE_COUNT(programGraphFeatures, val)            \
-  EXPECT_EQ(SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures,           \
-                                       "data_flow_active_node_count"), \
-            (val))
+#define EXPECT_ACTIVE_NODE_COUNT(programGraphFeatures, val) \
+  EXPECT_EQ(SCALAR_INT64_GRAPH_FEATURE(programGraphFeatures, "data_flow_active_node_count"), (val))
 
-#define EXPECT_NODE_FALSE(programGraphFeatures, nodeIndex)                     \
-  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_value", \
-                                      nodeIndex),                              \
-            0)
+#define EXPECT_NODE_FALSE(programGraphFeatures, nodeIndex) \
+  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_value", nodeIndex), 0)
 
-#define EXPECT_NODE_TRUE(programGraphFeatures, nodeIndex)                      \
-  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_value", \
-                                      nodeIndex),                              \
-            1)
+#define EXPECT_NODE_TRUE(programGraphFeatures, nodeIndex) \
+  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_value", nodeIndex), 1)
 
-#define EXPECT_NOT_ROOT(programGraphFeatures, nodeIndex)                 \
-  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures,              \
-                                      "data_flow_root_node", nodeIndex), \
-            0)
+#define EXPECT_NOT_ROOT(programGraphFeatures, nodeIndex) \
+  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_root_node", nodeIndex), 0)
 
-#define EXPECT_ROOT(programGraphFeatures, nodeIndex)                     \
-  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures,              \
-                                      "data_flow_root_node", nodeIndex), \
-            1)
+#define EXPECT_ROOT(programGraphFeatures, nodeIndex) \
+  EXPECT_EQ(SCALAR_INT64_NODE_FEATURE(programGraphFeatures, "data_flow_root_node", nodeIndex), 1)

--- a/programl/test/llvm_program_graphs.cc
+++ b/programl/test/llvm_program_graphs.cc
@@ -41,8 +41,7 @@ vector<ProtocolBuffer> ReadDirectoryOfProtos(const fs::path& path) {
 }
 
 vector<ProgramGraph> ReadLlvmProgramGraphs() {
-  const auto path =
-      labm8::BazelDataPathOrDie("programl/programl/test/data/llvm_ir_graphs");
+  const auto path = labm8::BazelDataPathOrDie("programl/programl/test/data/llvm_ir_graphs");
   return ReadDirectoryOfProtos<ProgramGraph>(path);
 }
 

--- a/programl/test/llvm_program_graphs.h
+++ b/programl/test/llvm_program_graphs.h
@@ -15,16 +15,14 @@
 // limitations under the License.
 #pragma once
 
-#include "programl/proto/program_graph.pb.h"
+#include <fstream>
+#include <vector>
 
+#include "boost/filesystem.hpp"
 #include "labm8/cpp/bazelutil.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/strutil.h"
-
-#include "boost/filesystem.hpp"
-
-#include <fstream>
-#include <vector>
+#include "programl/proto/program_graph.pb.h"
 
 namespace programl {
 namespace test {

--- a/programl/util/filesystem_cache.h
+++ b/programl/util/filesystem_cache.h
@@ -17,6 +17,7 @@
 
 #include <cstdlib>
 #include <vector>
+
 #include "boost/filesystem.hpp"
 #include "labm8/cpp/logging.h"
 
@@ -29,8 +30,7 @@ class FilesystemCache {
   FilesystemCache();
 
   // Convert the given key into a local filesystem path.
-  boost::filesystem::path operator[](
-      const std::vector<std::string>& components) const;
+  boost::filesystem::path operator[](const std::vector<std::string>& components) const;
 
  private:
   const boost::filesystem::path root_;

--- a/programl/util/nproc.cc
+++ b/programl/util/nproc.cc
@@ -16,6 +16,7 @@
 #include "programl/util/nproc.h"
 
 #include <string>
+
 #include "subprocess/subprocess.hpp"
 
 namespace programl {

--- a/programl/util/stdin_fmt.h
+++ b/programl/util/stdin_fmt.h
@@ -15,16 +15,15 @@
 // limitations under the License.
 #pragma once
 
-#include "labm8/cpp/app.h"
-#include "labm8/cpp/logging.h"
-#include "labm8/cpp/status.h"
+#include <iostream>
+#include <sstream>
 
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/json_util.h"
-
-#include <iostream>
-#include <sstream>
+#include "labm8/cpp/app.h"
+#include "labm8/cpp/logging.h"
+#include "labm8/cpp/status.h"
 
 DECLARE_string(stdin_fmt);
 

--- a/programl/util/stdout_fmt.cc
+++ b/programl/util/stdout_fmt.cc
@@ -15,16 +15,15 @@
 // limitations under the License.
 #include "programl/util/stdout_fmt.h"
 
-DEFINE_string(
-    stdout_fmt, "pbtxt",
-    "The format of output. Valid options are: "
-    "\"pbtxt\" for a text-format protocol buffer, "
-    "\"pb\" for a binary format protocol buffer, "
-    "or \"json\" for JSON. "
-    "Text format protocol buffers are recommended for human-readable output, "
-    "binary-format for efficient and fast file storage, and JSON for "
-    "processing "
-    "with third-party tools such as `jq`.");
+DEFINE_string(stdout_fmt, "pbtxt",
+              "The format of output. Valid options are: "
+              "\"pbtxt\" for a text-format protocol buffer, "
+              "\"pb\" for a binary format protocol buffer, "
+              "or \"json\" for JSON. "
+              "Text format protocol buffers are recommended for human-readable output, "
+              "binary-format for efficient and fast file storage, and JSON for "
+              "processing "
+              "with third-party tools such as `jq`.");
 
 // Assert that the stdout format is legal.
 static bool ValidateStdoutFormat(const char* flagname, const string& value) {

--- a/programl/util/stdout_fmt.h
+++ b/programl/util/stdout_fmt.h
@@ -15,13 +15,12 @@
 // limitations under the License.
 #pragma once
 
+#include <iostream>
+
+#include "google/protobuf/util/json_util.h"
 #include "labm8/cpp/app.h"
 #include "labm8/cpp/logging.h"
 #include "labm8/cpp/status.h"
-
-#include "google/protobuf/util/json_util.h"
-
-#include <iostream>
 
 DECLARE_string(stdout_fmt);
 
@@ -43,8 +42,7 @@ void WriteStdout(const ProtocolBuffer& message) {
     opts.always_print_enums_as_ints = false;
     opts.preserve_proto_field_names = true;
     std::string json;
-    CHECK(
-        google::protobuf::util::MessageToJsonString(message, &json, opts).ok());
+    CHECK(google::protobuf::util::MessageToJsonString(message, &json, opts).ok());
     std::cout << json << std::endl;
   } else {
     LOG(FATAL) << "unreachable! Unrecognized --stdout_fmt";

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Run the project code formatters.
+set -eu
+
+if [[ ! -f WORKSPACE ]]; then
+    echo "Must be ran from project root!" >&2
+fi
+
+find . -name '*.h' | xargs clang-format -i
+find . -name '*.cc' | xargs clang-format -i


### PR DESCRIPTION
This adds a `.clang-format` config, based on the default Google code style, with the following changes:
  * AllowShortIfStatementsOnASingleLine: Never
    Always force a linebreak in if/else blocks.
  * DerivePointerAlignment: false
    Always force the pointer '*' to the left (type).
  * ColumnLimit:     100
    Because, you know, who uses 80 char anymore? :-)

This adds a GitHub action to run clang-format using this config on every push/pull-request.

#100.