### PR TITLE
[install] Add workaround for LLVMPolly.so name error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,9 @@ jobs:
         run: |
           mkdir "${GITHUB_WORKSPACE}/install"
           bazel run --config=ci //:install "${GITHUB_WORKSPACE}/install"
+          echo "::add-path::${GITHUB_WORKSPACE}/install/bin"
+          echo "::set-env name=LD_LIBRARY_PATH::${GITHUB_WORKSPACE}/install/lib"
+
+      - name: Test installed binaries
+        run: |
+          llvm2graph --version

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,12 @@ main() {
   echo "Installing libraries to $prefix/libs ..."
   rsync -ah --delete --exclude '*.a' "$LLVM_LIBS/" "$prefix/lib/"
 
+  # NOTE(github.com/ChrisCummins/ProGraML/issues/134): Workaround for load-time
+  # errors when systems expect LLVMPolly.so to have the "lib" name prefix.
+  if [[ -f "$prefix/lib/LLVMPolly.so" ]]; then
+    ln -s "$prefix/lib/LLVMPolly.so" "$prefix/lib/libLLVMPolly.so"
+  fi
+
   echo
   echo "===================================================="
   echo "To use them, add the following to your ~/.$(basename $SHELL)rc:"


### PR DESCRIPTION
The shared library is named LLVMPolly.so, but some runtimes expect it to have
a lib prefix, causing a load-time error. This creates a symlink
libLLVMPolly.so -> LLVMPolly.so as a workaround.

I've added a smoke-test to the CI jobs to catch these linker errors early.

#134