### PR TITLE
Add types to graph (cherry-picked commit)

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -27,11 +27,11 @@ jobs:
                   go-version: ^1.13.1
             - name: Install buildifier
               run: |
-                  go get github.com/bazelbuild/buildtools/buildifier
+                  go install github.com/bazelbuild/buildtools/buildifier@latest
                   buildifier --version
             - name: Install prototool
               run: |
-                  GO111MODULE=on go get github.com/uber/prototool/cmd/prototool@dev
+                  GO111MODULE=on go install github.com/uber/prototool/cmd/prototool@dev
                   prototool version
             - name: Install Python 3.8
               uses: actions/setup-python@v2

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -43,7 +43,6 @@ jobs:
                   python3 -m pip install --upgrade wheel
                   python3 -m pip install -r tools/requirements.pre_commit.txt
                   python3 -m isort --version
-                  python3 -m black --version
                   python3 -m pre_commit --version
             - name: Run pre-commit checks
               # TODO(github.com/facebookresearch/CompilerGym/issues/1): Disable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
       hooks:
           - id: isort
     - repo: https://github.com/psf/black
-      rev: 20.8b1
+      rev: 22.3.0
       hooks:
           - id: black
             language_version: python3.8

--- a/programl/graph/program_graph_builder.cc
+++ b/programl/graph/program_graph_builder.cc
@@ -64,6 +64,8 @@ Node* ProgramGraphBuilder::AddVariable(const string& text, const Function* funct
 
 Node* ProgramGraphBuilder::AddConstant(const string& text) { return AddNode(Node::CONSTANT, text); }
 
+Node* ProgramGraphBuilder::AddType(const string& text) { return AddNode(Node::TYPE, text); }
+
 labm8::StatusOr<Edge*> ProgramGraphBuilder::AddControlEdge(int32_t position, const Node* source,
                                                            const Node* target) {
   DCHECK(source) << "nullptr argument";
@@ -129,6 +131,25 @@ labm8::StatusOr<Edge*> ProgramGraphBuilder::AddCallEdge(const Node* source, cons
   }
 
   return AddEdge(Edge::CALL, /*position=*/0, source, target);
+}
+
+labm8::StatusOr<Edge*> ProgramGraphBuilder::AddTypeEdge(int32_t position, const Node* source,
+                                                        const Node* target) {
+  DCHECK(source) << "nullptr argument";
+  DCHECK(target) << "nullptr argument";
+
+  if (source->type() != Node::TYPE) {
+    return Status(labm8::error::Code::INVALID_ARGUMENT,
+                  "Invalid source type ({}) for type edge. Expected type",
+                  Node::Type_Name(source->type()));
+  }
+  if (target->type() == Node::INSTRUCTION) {
+    return Status(labm8::error::Code::INVALID_ARGUMENT,
+                  "Invalid destination type (instruction) for type edge. "
+                  "Expected {variable,constant,type}");
+  }
+
+  return AddEdge(Edge::TYPE, position, source, target);
 }
 
 labm8::StatusOr<ProgramGraph> ProgramGraphBuilder::Build() {

--- a/programl/graph/program_graph_builder.h
+++ b/programl/graph/program_graph_builder.h
@@ -64,6 +64,8 @@ class ProgramGraphBuilder {
 
   Node* AddConstant(const string& text);
 
+  Node* AddType(const string& text);
+
   // Edge factories.
   [[nodiscard]] labm8::StatusOr<Edge*> AddControlEdge(int32_t position, const Node* source,
                                                       const Node* target);
@@ -72,6 +74,9 @@ class ProgramGraphBuilder {
                                                    const Node* target);
 
   [[nodiscard]] labm8::StatusOr<Edge*> AddCallEdge(const Node* source, const Node* target);
+
+  [[nodiscard]] labm8::StatusOr<Edge*> AddTypeEdge(int32_t position, const Node* source,
+                                                   const Node* target);
 
   const Node* GetRootNode() const { return &graph_.node(0); }
 
@@ -116,7 +121,7 @@ class ProgramGraphBuilder {
   int32_t GetIndex(const Function* function);
   int32_t GetIndex(const Node* node);
 
-  // Maps which covert store the index of objects in repeated field lists.
+  // Maps that store the index of objects in repeated field lists.
   absl::flat_hash_map<Module*, int32_t> moduleIndices_;
   absl::flat_hash_map<Function*, int32_t> functionIndices_;
   absl::flat_hash_map<Node*, int32_t> nodeIndices_;

--- a/programl/ir/llvm/inst2vec_encoder.py
+++ b/programl/ir/llvm/inst2vec_encoder.py
@@ -92,6 +92,7 @@ class Inst2vecEncoder(object):
         # Add the node features.
         var_embedding = self.dictionary["!IDENTIFIER"]
         const_embedding = self.dictionary["!IMMEDIATE"]
+        type_embedding = self.dictionary["!IMMEDIATE"]  # Types are immediates
 
         text_index = 0
         for node in proto.node:
@@ -113,6 +114,12 @@ class Inst2vecEncoder(object):
                 node.features.feature["inst2vec_embedding"].int64_list.value.append(
                     const_embedding
                 )
+            elif node.type == node_pb2.Node.TYPE:
+                node.features.feature["inst2vec_embedding"].int64_list.value.append(
+                    type_embedding
+                )
+            else:
+                raise TypeError(f"Unknown node type {node}")
 
         proto.features.feature["inst2vec_annotated"].int64_list.value.append(1)
         return proto

--- a/programl/ir/llvm/internal/program_graph_builder.h
+++ b/programl/ir/llvm/internal/program_graph_builder.h
@@ -70,6 +70,12 @@ class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
 
   void Clear();
 
+  // Return the node representing a type. If no node already exists
+  // for this type, a new node is created and added to the graph. In
+  // the case of composite types, multiple new nodes may be added by
+  // this call, and the root type returned.
+  Node* GetOrCreateType(const ::llvm::Type* type);
+
  protected:
   [[nodiscard]] labm8::StatusOr<FunctionEntryExits> VisitFunction(const ::llvm::Function& function,
                                                                   const Function* functionMessage);
@@ -85,6 +91,12 @@ class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
   Node* AddLlvmVariable(const ::llvm::Instruction* operand, const Function* function);
   Node* AddLlvmVariable(const ::llvm::Argument* argument, const Function* function);
   Node* AddLlvmConstant(const ::llvm::Constant* constant);
+  Node* AddLlvmType(const ::llvm::Type* type);
+  Node* AddLlvmType(const ::llvm::StructType* type);
+  Node* AddLlvmType(const ::llvm::PointerType* type);
+  Node* AddLlvmType(const ::llvm::FunctionType* type);
+  Node* AddLlvmType(const ::llvm::ArrayType* type);
+  Node* AddLlvmType(const ::llvm::VectorType* type);
 
  private:
   TextEncoder textEncoder_;
@@ -99,6 +111,26 @@ class ProgramGraphBuilder : public programl::graph::ProgramGraphBuilder {
   // populated by VisitBasicBlock() and consumed once all functions have been
   // visited.
   absl::flat_hash_map<const ::llvm::Constant*, std::vector<PositionalNode>> constants_;
+
+  // A map from an LLVM type to the node message that represents it.
+  absl::flat_hash_map<const ::llvm::Type*, Node*> types_;
+
+  // When adding a new type to the graph we need to know whether the type that
+  // we are adding is part of a composite type that references itself. For
+  // example:
+  //
+  //     struct BinaryTree {
+  //       int data;
+  //       struct BinaryTree* left;
+  //       struct BinaryTree* right;
+  //     }
+  //
+  // When the recursive GetOrCreateType() resolves the "left" member, it needs
+  // to know that the parent BinaryTree type has already been processed. This
+  // map stores the Nodes corresponding to any parent structs that have been
+  // already added in a call to GetOrCreateType(). It must be cleared between
+  // calls.
+  absl::flat_hash_map<const ::llvm::Type*, Node*> compositeTypeParts_;
 };
 
 }  // namespace internal

--- a/programl/proto/program_graph.proto
+++ b/programl/proto/program_graph.proto
@@ -55,6 +55,8 @@ message Node {
     VARIABLE = 1;
     // A constant.
     CONSTANT = 2;
+    // A type.
+    TYPE = 3;
   }
   // The type of the node.
   Type type = 1;
@@ -92,6 +94,8 @@ message Edge {
     DATA = 1;
     // A call relation.
     CALL = 2;
+    // A type relation.
+    TYPE = 3;
   }
   // The type of relation of this edge.
   Flow flow = 1;

--- a/tests/from_llvm_ir_test.py
+++ b/tests/from_llvm_ir_test.py
@@ -63,7 +63,7 @@ def test_module(simple_ir_graph):
 
 
 def test_num_nodes(simple_ir_graph):
-    assert len(simple_ir_graph.node) == 19
+    assert len(simple_ir_graph.node) == 21
 
 
 def test_node_types(simple_ir_graph):
@@ -74,6 +74,8 @@ def test_node_types(simple_ir_graph):
         pg.proto.Node.INSTRUCTION,
         pg.proto.Node.INSTRUCTION,
         pg.proto.Node.VARIABLE,
+        pg.proto.Node.TYPE,
+        pg.proto.Node.TYPE,
         pg.proto.Node.INSTRUCTION,
         pg.proto.Node.VARIABLE,
         pg.proto.Node.INSTRUCTION,
@@ -98,21 +100,23 @@ def test_node_texts(simple_ir_graph):
         "alloca",
         "alloca",
         "store",
-        "i32*",
+        "var",
+        "*",
+        "i32",
         "store",
-        "i32*",
+        "var",
         "load",
-        "i32*",
+        "var",
         "load",
-        "i32*",
+        "var",
         "add",
-        "i32",
-        "i32",
+        "var",
+        "var",
         "ret",
-        "i32",
-        "i32",
-        "i32",
-        "i32",
+        "var",
+        "var",
+        "var",
+        "val",
     ]
 
 
@@ -122,11 +126,14 @@ def test_node_full_texts(simple_ir_graph):
         for n in simple_ir_graph.node[1:]
     ]
     # The order of the last two variables may differ.
+    print("\n".join(full_texts))
     assert full_texts == [
         "%3 = alloca i32, align 4",
         "%4 = alloca i32, align 4",
         "store i32 %0, i32* %3, align 4",
         "i32* %3",
+        "i32*",
+        "i32",
         "store i32 %1, i32* %4, align 4",
         "i32* %4",
         "%5 = load i32, i32* %3, align 4",
@@ -146,6 +153,8 @@ def test_node_full_texts(simple_ir_graph):
         "%4 = alloca i32, align 4",
         "store i32 %0, i32* %3, align 4",
         "i32* %3",
+        "i32*",
+        "i32",
         "store i32 %1, i32* %4, align 4",
         "i32* %4",
         "%5 = load i32, i32* %3, align 4",

--- a/tools/requirements.pre_commit.txt
+++ b/tools/requirements.pre_commit.txt
@@ -1,3 +1,3 @@
-black==19.10b0
-isort>=4.3.21
-pre-commit>=2.9.0
+isort==4.3.21
+pre-commit>=2.12.1
+setuptools


### PR DESCRIPTION
This supersedes #94 as a standalone commit.

This adds a fourth node type, and a fourth edge flow, both called
"type". The idea is to represent types as first-class elements in the
graph representation. This allows greater compositionality by breaking
up composite types into subcomponents, and decreases the required
vocabulary size required to achieve a given coverage.

Background
----------

Currently, type information is stored in the "text" field of nodes for
constants and variables, e.g.:

    node {
      type: VARIABLE
      text: "i8"
    }

![image](https://user-images.githubusercontent.com/1636663/90941540-4e23db00-e40a-11ea-950a-227a6f10f496.png)

There are two issues with this:

 * Composite types end up with long textual representations,
   e.g. "struct foo { i32 a; i32 b; ... }". Since there is an
   unbounded number of possible structs, this prevents 100% vocabulary
   coverage on any IR with structs (or other composite types).

 * In the future, we will want to encode different information on data
   nodes, such as embedding literal values. Moving the type information
   out of the data node "frees up" space for something else.

Overview
--------

This changes the representation to represent types as first-class
elements in the graph. A "type" node represents a type using its
"text" field, and a new "type" edge connects this type to variables or
constants of that type, e.g. a variable "int x" could be represented as:

    node {
      type: VARIABLE
      text: "var"
    }
    node {
      type: TYPE
      text: "i32"
    }
    edge {
      flow: TYPE
      source: 1
    }

![image](https://user-images.githubusercontent.com/1636663/90941572-6693f580-e40a-11ea-883e-eb170f5f9ab2.png)

Composite types
---------------

Types may be composed by connecting multiple type nodes using type
edges. This allows you to break down complex types into a graph of
primitive parts. The meaning of composite types will depend on the
IR being targetted, the remainder describes the process for
LLVM-IR.

Pointer types
-------------

A pointer is a composite of two types:

    [variable] <- [pointer] <- [pointed-type]

For example:

    int32_t* instance;

Would be represented as:

    node {
      type: TYPE
      text: "i32"
    }
    node {
      type: TYPE
      text: "*"
    }
    node {
      type: VARIABLE
      text: "var"
    }
    edge {
      text: TYPE
      target: 1
    }
    edge {
      text: TYPE
      source: 1
      target: 2
    }

Where variables/constants of this type receive an incoming type edge
from the [pointer] node, which in turn receives an incoming type edge
from the [pointed-type] node.

One [pointer] node is generated for each unique pointer type. If a
graph contains multiple pointer types, there will be multiple
[pointer] nodes, one for each pointed type.

### Example

![](https://user-images.githubusercontent.com/1636663/90942172-8d532b80-e40c-11ea-9144-4c9e2a583eeb.png)

Generated using:

```
cat <<EOF | clang2graph -xc - | graph2dot
int *A() {
  int a;
  return &a;
}
EOF
```

Struct types
------------

A struct is a compsite type where each member is a node type which
points to the parent node. Variable/constant instances of a struct
receive an incoming type edge from the root struct node. Note that
the graph of type nodes representing a composite struct type may be
cyclical, since a struct can contain a pointer of the same type (think
of a binary tree implementation). For all other member types, a new
type node is produced. For example, a struct with two integer members
will produce two integer type nodes, they are not shared.

The type edges from member nodes to the parent struct are
positional. The position indicates the element number. E.g. for a
struct with three elements, the incoming type edges to the struct node
will have positions 0, 1, and 2.

This example struct:

    struct s {
      int8_t a;
      int8_t b;
      struct s* c;
    }

    struct s instance;

Would be represented as:

    node {
      type: TYPE
      text: "struct"
    }
    node {
      type: TYPE
      text: "i8"
    }
    node {
      type: TYPE
      text: "i8"
    }
    node {
      type: TYPE
      text: "*"
    }
    node {
      type: VARIABLE
      text: "var"
    }
    edge {
      flow: TYPE
      target: 1
    }
    edge {
      flow: TYPE
      target: 2
      position: 1
    }
    edge {
      flow: TYPE
      target: 3
      position: 2
    }
    edge {
      flow: TYPE
      source: 3
    }
    edge {
      flow: TYPE
      target: 4
    }

### Example

![](https://user-images.githubusercontent.com/1636663/90944455-c4c6d580-e416-11ea-908c-b8e9c1c868fe.png)

Generated using:

```
cat <<EOF | clang2graph -xc - | graph2dot
struct S {
  char a;
  char b;
  struct S* c;
};

char A() {
  struct S s;
  return s.a;
}
EOF
```

Array Types
-----------

An array is a composite type [variable] <- [array] <- [element-type].
For example, the array:

    int a[10];

Would be represented as:

    node {
      type: TYPE
      text: "i32"
    }
    node {
      type: TYPE
      text: "[]"
    }
    node {
      type: VARIABLE
      text: "var"
    }
    edge {
      flow: TYPE
      target: 1
    }
    edge {
      flow: TYPE
      source: 1
      target: 2
    }

### Example

![](https://user-images.githubusercontent.com/1636663/90941897-634d3980-e40b-11ea-871a-9744bb20921a.png)

Generated using:

```
cat <<EOF | clang2graph -xc - | graph2dot
int* A() {
  int a[10];
  return a;
}
EOF
```

Function Pointers
---------------

A function pointer is represented by a type node that uniquely identifies 
the *signature* of a function, i.e. its return type and parameter types. The 
caveat of this is that pointers to different functions which have the same 
signature will resolve to the same type node. Additionally, there is no edge 
connecting a function pointer type and the instructions which belong to this 
function.

### Example

This program contains two function signatures (`int (void)` and 
`float (void)`), but function pointers to three different functions. This 
highlights the caveat described above as the function pointers `a` and `b` 
alias to the same type node:

![](https://user-images.githubusercontent.com/1636663/91032425-d4524400-e5f9-11ea-9d93-e8e3cd1aed95.png)

Generated using:

```
br -c opt //:install && cat <<EOF | clang2graph -xc - | graph2dot
int A() {
  return 10;
}

int B() {
  return 5;
}

float C() {
  return 15;
}

int D() {
  int (*a)() = &A;
  int (*b)() = &B;
  float (*c)() = &C;
  return (*a)() + (*b)() + (*c)();
}
EOF
```

#82 