### PR TITLE
Kill process after timeout expired

### DIFF
--- a/programl/create_ops.py
+++ b/programl/create_ops.py
@@ -167,6 +167,7 @@ def from_cpp(
         try:
             stdout, stderr = process.communicate(src.encode("utf-8"), timeout=timeout)
         except subprocess.TimeoutExpired as e:
+            process.kill()
             raise TimeoutError(str(e)) from e
 
         return _graph_from_subprocess(process, stdout, stderr)
@@ -268,6 +269,7 @@ def from_clang(
         try:
             stdout, stderr = process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired as e:
+            process.kill()
             raise TimeoutError(str(e)) from e
 
         return _graph_from_subprocess(process, stdout, stderr)
@@ -355,6 +357,7 @@ def from_llvm_ir(
         try:
             stdout, stderr = process.communicate(ir.encode("utf-8"), timeout=timeout)
         except subprocess.TimeoutExpired as e:
+            process.kill()
             raise TimeoutError(str(e)) from e
 
         return _graph_from_subprocess(process, stdout, stderr)
@@ -416,6 +419,7 @@ def from_xla_hlo_proto(
                 hlo.SerializeToString(), timeout=timeout
             )
         except subprocess.TimeoutExpired as e:
+            process.kill()
             raise TimeoutError(str(e)) from e
 
         return _graph_from_subprocess(process, stdout, stderr)


### PR DESCRIPTION
Spawned processes are not properly cleaned up after a TimeoutExpired exception. This could cause a huge increase in memory usage as more and more TimeoutExpired exceptions are raised (e.g. when converting a dataset with very large files, or when the timeout is set too low.  

Quoting from the documentation for the "communicate" function ([https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate)): 
> The child process is not killed if the timeout expires, so in order to cleanup properly a well-behaved application should kill the child process and finish communication.

Therefore, I propose to explicitly kill these expired processes. I tested this fix on my local environment and it works as expected.